### PR TITLE
ci: restrict GITHUB_TOKEN permissions to contents: read

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a workflow-level `permissions` block to `build.yml`
- Restricts `GITHUB_TOKEN` to `contents: read` (needed for `actions/checkout`)
- Neither job uses any write permissions, so this follows least-privilege

## Test plan

- [ ] Verify the `unit-tests` job passes with the restricted token
- [ ] Verify the `ui-tests` job passes with the restricted token

🤖 Generated with [Claude Code](https://claude.com/claude-code)