### PR TITLE
ci: cache Gradle configuration cache to skip task graph recalculation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,13 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      - name: Create API key properties file  
+      - name: Cache Gradle configuration cache
+        uses: actions/cache@v5
+        with:
+          path: .gradle/configuration-cache
+          key: configuration-cache-${{ hashFiles('**/*.gradle.kts', '**/gradle.properties', '**/libs.versions.toml') }}
+
+      - name: Create API key properties file
         run: echo "BOOKS_API_KEY=\"fake-key-for-ci\"" > core-network/apikey.properties
 
       - name: Run unit tests
@@ -57,7 +63,13 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      - name: Create API key properties file  
+      - name: Cache Gradle configuration cache
+        uses: actions/cache@v5
+        with:
+          path: .gradle/configuration-cache
+          key: configuration-cache-${{ hashFiles('**/*.gradle.kts', '**/gradle.properties', '**/libs.versions.toml') }}
+
+      - name: Create API key properties file
         run: echo "BOOKS_API_KEY=\"fake-key-for-ci\"" > core-network/apikey.properties
 
       - name: Enable KVM group perms


### PR DESCRIPTION
## What changed

Added an explicit `actions/cache` step for `.gradle/configuration-cache` to both the `unit-tests` and `ui-tests` jobs in the CI workflow.

## Why

The Gradle configuration cache (which stores the resolved task graph) lives at the project level under `.gradle/configuration-cache/`, not in `~/.gradle`. Because `gradle/actions/setup-gradle` only caches `~/.gradle`, the configuration cache was being rebuilt from scratch on every CI run — the "Calculating task graph as no cached configuration is available" message in the logs confirms this.

## How it works

The cache key is a hash of all `*.gradle.kts`, `gradle.properties`, and `libs.versions.toml` files. When none of those change between runs, Gradle can reuse the cached task graph and skip the configuration phase entirely. The key automatically invalidates whenever any build file is modified, preventing stale cache hits.

## Notes for reviewer

- The existing `gradle/actions/setup-gradle@v5` step already handles the Gradle build cache (task output caching) — this is an additive change on top of that.
- No changes to `gradle.properties`; `org.gradle.configuration-cache=true` was already set there.