### PR TITLE
feat: show add-book success message on the bookshelf

### DIFF
--- a/app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt
+++ b/app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt
@@ -15,6 +15,7 @@ import com.sriniketh.core_platform.decodeUri
 import com.sriniketh.core_platform.encodeUri
 import com.sriniketh.feature_addhighlight.CaptureAndCropImageScreen
 import com.sriniketh.feature_addhighlight.EditAndSaveHighlightScreen
+import com.sriniketh.feature_bookshelf.BOOKSHELF_SHOW_ADDED_MESSAGE
 import com.sriniketh.feature_bookshelf.BookshelfScreen
 import com.sriniketh.feature_searchbooks.BookInfoScreen
 import com.sriniketh.feature_searchbooks.SearchBookScreen
@@ -162,7 +163,12 @@ internal fun ProseAppScreen(
                         modifier = modifier,
                         bookId = backStackEntry.arguments?.getString(Screen.BOOKINFO.argBookId)
                             .orEmpty(),
-                        goBack = { navController.navigateUp() }
+                        goBack = { navController.navigateUp() },
+                        onBookAddedToShelf = {
+                            navController.getBackStackEntry(Screen.BOOKSHELF.route)
+                                .savedStateHandle[BOOKSHELF_SHOW_ADDED_MESSAGE] = true
+                            navController.popBackStack(Screen.BOOKSHELF.route, inclusive = false)
+                        }
                     )
                 }
             }

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfViewModel.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfViewModel.kt
@@ -1,6 +1,7 @@
 package com.sriniketh.feature_bookshelf
 
 import androidx.annotation.StringRes
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sriniketh.core_data.usecases.GetAllSavedBooksUseCase
@@ -16,9 +17,12 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+const val BOOKSHELF_SHOW_ADDED_MESSAGE = "bookshelf_show_added_message"
+
 @HiltViewModel
 class BookshelfViewModel @Inject constructor(
-    private val getAllSavedBooksUseCase: GetAllSavedBooksUseCase
+    private val getAllSavedBooksUseCase: GetAllSavedBooksUseCase,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     private val _bookshelfUIState: MutableStateFlow<BookshelfUIState> =
@@ -31,6 +35,15 @@ class BookshelfViewModel @Inject constructor(
     var viewHighlightsForBook: (String) -> Unit = {}
 
     init {
+        viewModelScope.launch {
+            savedStateHandle.getStateFlow(BOOKSHELF_SHOW_ADDED_MESSAGE, false)
+                .collect { showAddedMessage ->
+                    if (showAddedMessage) {
+                        _effects.trySend(BookshelfEffect.ShowMessage(R.string.book_added_to_shelf_message))
+                        savedStateHandle[BOOKSHELF_SHOW_ADDED_MESSAGE] = false
+                    }
+                }
+        }
         viewModelScope.launch {
             _bookshelfUIState.update { state ->
                 state.copy(isLoading = true)

--- a/feature-bookshelf/src/main/res/values/strings.xml
+++ b/feature-bookshelf/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="bookshelf_empty_text">Go ahead, grab a book!</string>
     <string name="getallbooks_error_message">Error retrieving saved books.</string>
     <string name="search_fab_cont_desc">search for a book button</string>
+    <string name="book_added_to_shelf_message">Book has been added to shelf!</string>
 </resources>

--- a/feature-bookshelf/src/test/java/com/sriniketh/feature_bookshelf/BookshelfViewModelTest.kt
+++ b/feature-bookshelf/src/test/java/com/sriniketh/feature_bookshelf/BookshelfViewModelTest.kt
@@ -1,11 +1,13 @@
 package com.sriniketh.feature_bookshelf
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.sriniketh.core_data.usecases.GetAllSavedBooksUseCase
 import com.sriniketh.feature_bookshelf.fakes.FakeBooksRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -36,7 +38,7 @@ class BookshelfViewModelTest {
 
     @Test
     fun `when initialized then state has correct defaults`() = runTest {
-        val viewModel = BookshelfViewModel(getAllSavedBooksUseCase)
+        val viewModel = BookshelfViewModel(getAllSavedBooksUseCase, SavedStateHandle())
 
         viewModel.bookshelfUIState.test {
             val initialState = awaitItem()
@@ -49,7 +51,7 @@ class BookshelfViewModelTest {
     @Test
     fun `when initialized books are loaded and ui state transitions from loading to loaded`() =
         runTest {
-            val viewModel = BookshelfViewModel(getAllSavedBooksUseCase)
+            val viewModel = BookshelfViewModel(getAllSavedBooksUseCase, SavedStateHandle())
 
             viewModel.bookshelfUIState.test {
                 val initialState = awaitItem()
@@ -67,7 +69,7 @@ class BookshelfViewModelTest {
 
     @Test
     fun `when initialized ui state contains book details`() = runTest {
-        val viewModel = BookshelfViewModel(getAllSavedBooksUseCase)
+        val viewModel = BookshelfViewModel(getAllSavedBooksUseCase, SavedStateHandle())
 
         viewModel.bookshelfUIState.test {
             skipItems(2)
@@ -87,7 +89,7 @@ class BookshelfViewModelTest {
     @Test
     fun `when initialized and loading fails then show error`() = runTest {
         fakeBooksRepository.shouldGetAllSavedBooksFromDbThrowException = true
-        val failingViewModel = BookshelfViewModel(GetAllSavedBooksUseCase(fakeBooksRepository))
+        val failingViewModel = BookshelfViewModel(GetAllSavedBooksUseCase(fakeBooksRepository), SavedStateHandle())
 
         failingViewModel.effects.test {
             assertEquals(
@@ -105,7 +107,7 @@ class BookshelfViewModelTest {
     fun `when error occurs then effect is delivered once and not re-delivered to a new collector`() =
         runTest {
             fakeBooksRepository.shouldGetAllSavedBooksFromDbThrowException = true
-            val failingViewModel = BookshelfViewModel(GetAllSavedBooksUseCase(fakeBooksRepository))
+            val failingViewModel = BookshelfViewModel(GetAllSavedBooksUseCase(fakeBooksRepository), SavedStateHandle())
 
             failingViewModel.effects.test {
                 assertEquals(
@@ -122,7 +124,7 @@ class BookshelfViewModelTest {
 
     @Test
     fun `when view highlights for book is set then book view action uses it`() = runTest {
-        val viewModel = BookshelfViewModel(getAllSavedBooksUseCase)
+        val viewModel = BookshelfViewModel(getAllSavedBooksUseCase, SavedStateHandle())
         var calledBookId: String? = null
         viewModel.viewHighlightsForBook = { bookId -> calledBookId = bookId }
 
@@ -136,5 +138,23 @@ class BookshelfViewModelTest {
 
             assertEquals("test-id", calledBookId)
         }
+    }
+
+    @Test
+    fun `when book added flag is set then added message is emitted and cleared`() = runTest {
+        val savedStateHandle = SavedStateHandle(
+            mapOf(BOOKSHELF_SHOW_ADDED_MESSAGE to true)
+        )
+        val viewModel = BookshelfViewModel(getAllSavedBooksUseCase, savedStateHandle)
+
+        viewModel.effects.test {
+            assertEquals(
+                BookshelfEffect.ShowMessage(R.string.book_added_to_shelf_message),
+                awaitItem()
+            )
+        }
+        advanceUntilIdle()
+
+        assertEquals(false, savedStateHandle.get<Boolean>(BOOKSHELF_SHOW_ADDED_MESSAGE))
     }
 }

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -65,7 +65,8 @@ fun BookInfoScreen(
     modifier: Modifier = Modifier,
     viewModel: BookInfoViewModel = hiltViewModel(),
     bookId: String,
-    goBack: () -> Unit
+    goBack: () -> Unit,
+    onBookAddedToShelf: () -> Unit = {}
 ) {
     LaunchedEffect(key1 = bookId) {
         viewModel.getBookDetail(bookId)
@@ -83,7 +84,7 @@ fun BookInfoScreen(
                     is BookInfoEffect.ShowMessage -> scope.launch {
                         snackbarHostState.showSnackbar(context.getString(effect.messageRes))
                     }
-                    BookInfoEffect.NavigateToBookshelf -> goBack()
+                    BookInfoEffect.NavigateToBookshelf -> onBookAddedToShelf()
                 }
             }
         }

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -83,6 +83,7 @@ fun BookInfoScreen(
                     is BookInfoEffect.ShowMessage -> scope.launch {
                         snackbarHostState.showSnackbar(context.getString(effect.messageRes))
                     }
+                    BookInfoEffect.NavigateToBookshelf -> goBack()
                 }
             }
         }

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt
@@ -71,7 +71,7 @@ class BookInfoViewModel @Inject constructor(
                         canAddToShelf = false
                     )
                 }
-                _effects.trySend(BookInfoEffect.ShowMessage(R.string.add_to_bookshelf_success_message))
+                _effects.trySend(BookInfoEffect.NavigateToBookshelf)
             } else if (result.isFailure) {
                 _uiState.update { state ->
                     state.copy(isLoading = false)
@@ -91,4 +91,5 @@ data class BookInfoUiState(
 
 internal sealed interface BookInfoEffect {
     data class ShowMessage(@StringRes val messageRes: Int) : BookInfoEffect
+    data object NavigateToBookshelf : BookInfoEffect
 }

--- a/feature-searchbooks/src/main/res/values/strings.xml
+++ b/feature-searchbooks/src/main/res/values/strings.xml
@@ -9,7 +9,6 @@
     <string name="nav_label_book_info">Book info</string>
     <string name="add_to_shelf_button_text">Add to shelf</string>
     <string name="book_info_load_error_message">Error loading book details.</string>
-    <string name="add_to_bookshelf_success_message">Book has been added to shelf!</string>
     <string name="add_to_bookshelf_error_message">Error adding book to bookshelf.</string>
     <string name="book_info_ratings_template">Ratings: %1$.2f/5.0 out of %2$d reviews</string>
     <string name="book_info_pagecount_template">Number of pages: %1$d</string>

--- a/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/BookInfoViewModelTest.kt
+++ b/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/BookInfoViewModelTest.kt
@@ -163,7 +163,7 @@ class BookInfoViewModelTest {
     }
 
     @Test
-    fun `when add book to shelf succeeds then success message is emitted`() = runTest {
+    fun `when add book to shelf succeeds then navigate to bookshelf effect is emitted`() = runTest {
         fakeBooksRepository.doesBookExistResult = false
 
         viewModel.getBookDetail("test-volume-id")
@@ -175,7 +175,7 @@ class BookInfoViewModelTest {
             addToShelf()
 
             assertEquals(
-                BookInfoEffect.ShowMessage(R.string.add_to_bookshelf_success_message),
+                BookInfoEffect.NavigateToBookshelf,
                 awaitItem()
             )
         }


### PR DESCRIPTION
## Summary

When a user adds a book from `BookInfoScreen`, the app now navigates back to `BookshelfScreen` and shows the add-success snackbar **on the bookshelf** — instead of staying on the book-info screen and showing it there.

## How it works

The flow keeps feature modules decoupled and reuses the existing channel-based effects path (PR #92):

1. **`feature-searchbooks` · `BookInfoViewModel`** — the add-success branch now emits a payload-free `data object NavigateToBookshelf` effect instead of a local `ShowMessage` snackbar. `ShowMessage` is retained for the two error branches.
2. **`feature-searchbooks` · `BookInfoScreen`** — gains `onBookAddedToShelf: () -> Unit`; the `NavigateToBookshelf` effect invokes it.
3. **`app` · `ProseAppScreen`** — `onBookAddedToShelf` sets a one-shot boolean flag on the bookshelf back-stack entry's `SavedStateHandle`, then `popBackStack` to the bookshelf.
4. **`feature-bookshelf` · `BookshelfViewModel`** — scoped to the bookshelf entry, so Hilt injects that same `SavedStateHandle`. It observes the flag, emits `BookshelfEffect.ShowMessage` with its **own** new `book_added_to_shelf_message` string, then clears the flag.

### Message ownership
The success message is shown *on* the bookshelf, so `feature-bookshelf` owns the string — no `@StringRes` id is passed across the module boundary, and the now-dead `feature-searchbooks` `add_to_bookshelf_success_message` string is removed. This matches the repo convention that each feature module owns its own strings and avoids an invisible cross-module coupling.

### One-shot correctness
The flag rides the bookshelf back-stack entry's `SavedStateHandle` (survives config change / process death). It is cleared synchronously right after the effect is sent, and `getStateFlow` deduplication means the snackbar fires exactly once per add.

## Testing

- `./gradlew test` — full JVM unit suite passes.
- Updated `BookInfoViewModelTest` to assert the success branch emits `NavigateToBookshelf`.
- Added `BookshelfViewModelTest` covering the flag → `ShowMessage` emission and flag clearing.
- **Instrumented tests pass** on an **API 34** emulator: `:feature-bookshelf:connectedDebugAndroidTest` (10 tests) and `:feature-searchbooks:connectedDebugAndroidTest` (24 tests), all green.
  - ⚠️ They must be run on **API ≤ 35**. On API 36 (Android 16) every instrumented test fails fast with `NoSuchMethodException: android.hardware.input.InputManager.getInstance` — a pre-existing Espresso 3.7.0 vs Android 16 incompatibility (the platform removed the hidden `InputManager.getInstance()` that Espresso's input injection reflects into; Compose UI tests hit it via `Espresso.onIdle()`). This is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)