### PR TITLE
feat: migrate from Google Books API to Open Library API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,6 @@ jobs:
           path: .gradle/configuration-cache
           key: configuration-cache-${{ hashFiles('**/*.gradle.kts', '**/gradle.properties', '**/libs.versions.toml') }}
 
-      - name: Create API key properties file
-        run: echo "BOOKS_API_KEY=\"fake-key-for-ci\"" > core-network/apikey.properties
-
       - name: Run unit tests
         run: ./gradlew test
 
@@ -68,9 +65,6 @@ jobs:
         with:
           path: .gradle/configuration-cache
           key: configuration-cache-${{ hashFiles('**/*.gradle.kts', '**/gradle.properties', '**/libs.versions.toml') }}
-
-      - name: Create API key properties file
-        run: echo "BOOKS_API_KEY=\"fake-key-for-ci\"" > core-network/apikey.properties
 
       - name: Enable KVM group perms
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents like Claude Code (claude.ai/code
 ## Build Commands
 
 ```bash
-# Build the project (requires API key setup first)
+# Build the project
 ./gradlew assembleDebug
 
 # Run all unit tests
@@ -23,13 +23,6 @@ This file provides guidance to AI coding agents like Claude Code (claude.ai/code
 ./gradlew :feature-bookshelf:connectedDebugAndroidTest
 ```
 
-## API Key Setup
-
-Before building, create `core-network/apikey.properties` with:
-```
-BOOKS_API_KEY="your-google-books-api-key"
-```
-
 ## Architecture Overview
 
 Prose is a multi-module Android app for capturing book highlights from physical books using OCR (ML Kit). It follows unidirectional data flow (UDF) with Jetpack Compose UI. Uses JVM toolchain 17.
@@ -37,7 +30,7 @@ Prose is a multi-module Android app for capturing book highlights from physical 
 ### Module Structure
 
 **Core Modules:**
-- `core-network` - Retrofit API client for Google Books API (Moshi for JSON)
+- `core-network` - Retrofit API client for the Open Library API (kotlinx.serialization for JSON)
 - `core-db` - Room database with `BookEntity` and `HighlightEntity`
 - `core-data` - Repositories and UseCases that combine network/db operations
 - `core-models` - Domain models (`Book`, `Highlight`, `BookSearch`) — pure Kotlin, no Android deps
@@ -75,7 +68,7 @@ Navigation Compose with routes defined in `app/src/main/java/com/sriniketh/prose
 ### Key Libraries
 
 - **Compose BOM** for UI with Material 3 + DynamicColors
-- **Retrofit 3 + Moshi** for networking
+- **Retrofit 3 + kotlinx.serialization** for networking
 - **Room** for local persistence
 - **Coil** for image loading
 - **Cropify** for image cropping

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Prose is an Android app to capture and save highlights from physical books.
 
-The app uses the [Google Play Books API](https://developers.google.com/books) to search for a book
+The app uses the [Open Library API](https://openlibrary.org/developers/api) to search for a book
 and obtain rich content for the same. Books can be saved into a bookshelf and highlights can be
 added for each saved book. Text recognition is performed
 on-device using [ML Kit](https://developers.google.com/ml-kit/vision/text-recognition/android).
@@ -34,8 +34,7 @@ align UI colors with the color theme of the wallpaper in both dark and light mod
 
 ## Building the project
 
-The project requires a Google Books API key that needs to be added to a `apikey.properties` file in
-the `core-network` module.
+The Open Library API requires no API key, so the project builds with no additional setup.
 
 The app is setup as a multi-module project containing core and feature modules. It follows the
 unidirectional data flow model where data flows from the network/database layers to the presentation

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ align UI colors with the color theme of the wallpaper in both dark and light mod
 
 ## Building the project
 
-The Open Library API requires no API key, so the project builds with no additional setup.
-
 The app is setup as a multi-module project containing core and feature modules. It follows the
 unidirectional data flow model where data flows from the network/database layers to the presentation
 layer where it's reduced to UI state. This state is then consumed and rendered as UI using Compose.

--- a/app/src/main/java/com/sriniketh/prose/dagger/AppModule.kt
+++ b/app/src/main/java/com/sriniketh/prose/dagger/AppModule.kt
@@ -1,11 +1,14 @@
 package com.sriniketh.prose.dagger
 
 import com.sriniketh.core_platform.FileSource
+import com.sriniketh.prose.BuildConfig
 import com.sriniketh.prose.files.FileSourceImpl
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -13,4 +16,11 @@ abstract class AppModule {
 
     @Binds
     abstract fun fileSource(impl: FileSourceImpl): FileSource
+
+    companion object {
+
+        @Provides
+        @Named("userAgent")
+        fun providesUserAgent(): String = "Prose/${BuildConfig.VERSION_NAME}"
+    }
 }

--- a/core-network/build.gradle.kts
+++ b/core-network/build.gradle.kts
@@ -1,16 +1,9 @@
-import java.util.Properties
-import java.io.FileInputStream
-
 plugins {
 	alias(libs.plugins.android.library)
 	alias(libs.plugins.kotlin.serialization)
 	alias(libs.plugins.hilt)
 	alias(libs.plugins.ksp)
 }
-
-val apikeyPropertiesFile = file("apikey.properties")
-val apikeyProperties = Properties()
-apikeyProperties.load(FileInputStream(apikeyPropertiesFile))
 
 kotlin {
 	jvmToolchain(libs.versions.jvmToolchainVersion.get().toInt())
@@ -25,7 +18,6 @@ android {
 	defaultConfig {
 		minSdk = libs.versions.minSdkVersion.get().toInt()
 
-		buildConfigField("String", "BOOKS_API_KEY", apikeyProperties["BOOKS_API_KEY"] as String)
 		consumerProguardFiles("consumer-rules.pro")
 	}
 

--- a/core-network/src/main/java/com/sriniketh/prose/core_network/di/NetworkModule.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/di/NetworkModule.kt
@@ -13,6 +13,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -26,14 +27,16 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun providesRemoteJson(): BooksApi = Retrofit.Builder()
+    fun providesRemoteJson(
+        @Named("userAgent") userAgent: String
+    ): BooksApi = Retrofit.Builder()
         .baseUrl("https://openlibrary.org/")
         .client(
             OkHttpClient.Builder()
                 .addInterceptor { chain ->
                     chain.proceed(
                         chain.request().newBuilder()
-                            .header("User-Agent", "Prose Android App")
+                            .header("User-Agent", userAgent)
                             .build()
                     )
                 }

--- a/core-network/src/main/java/com/sriniketh/prose/core_network/di/NetworkModule.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/di/NetworkModule.kt
@@ -27,9 +27,16 @@ object NetworkModule {
     @Provides
     @Singleton
     fun providesRemoteJson(): BooksApi = Retrofit.Builder()
-        .baseUrl("https://www.googleapis.com")
+        .baseUrl("https://openlibrary.org/")
         .client(
             OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    chain.proceed(
+                        chain.request().newBuilder()
+                            .header("User-Agent", "Prose Android App")
+                            .build()
+                    )
+                }
                 .addInterceptor(
                     HttpLoggingInterceptor().apply {
                         setLevel(

--- a/core-network/src/main/java/com/sriniketh/prose/core_network/mapper/OpenLibraryMappers.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/mapper/OpenLibraryMappers.kt
@@ -1,0 +1,31 @@
+package com.sriniketh.prose.core_network.mapper
+
+import com.sriniketh.prose.core_network.model.ImageLinks
+import com.sriniketh.prose.core_network.model.OpenLibraryDoc
+import com.sriniketh.prose.core_network.model.OpenLibrarySearchResponse
+import com.sriniketh.prose.core_network.model.Volume
+import com.sriniketh.prose.core_network.model.VolumeInfo
+import com.sriniketh.prose.core_network.model.Volumes
+
+internal fun OpenLibrarySearchResponse.asVolumes(): Volumes =
+    Volumes(items = docs.map { it.asVolume() })
+
+internal fun OpenLibraryDoc.asVolume(description: String? = null): Volume =
+    Volume(
+        id = key.removePrefix("/works/"),
+        volumeInfo = VolumeInfo(
+            title = title,
+            subtitle = subtitle,
+            description = description,
+            authors = authorName ?: emptyList(),
+            imageLinks = coverId?.let { ImageLinks(thumbnail = coverImageUrl(it)) },
+            publisher = publisher?.firstOrNull(),
+            publishedDate = firstPublishYear?.toString(),
+            pageCount = numberOfPagesMedian,
+            averageRating = ratingsAverage,
+            ratingsCount = ratingsCount
+        )
+    )
+
+private fun coverImageUrl(coverId: Int): String =
+    "https://covers.openlibrary.org/b/id/$coverId-M.jpg"

--- a/core-network/src/main/java/com/sriniketh/prose/core_network/model/OpenLibraryModels.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/model/OpenLibraryModels.kt
@@ -28,9 +28,6 @@ data class OpenLibraryWork(
     val description: WorkDescription? = null
 )
 
-// No @Serializable: Open Library returns `description` as either a bare string or a
-// {type, value} object, so (de)serialization is handled entirely by WorkDescriptionSerializer,
-// applied at the use site on OpenLibraryWork.description.
 data class WorkDescription(
     val value: String?
 )

--- a/core-network/src/main/java/com/sriniketh/prose/core_network/model/OpenLibraryModels.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/model/OpenLibraryModels.kt
@@ -1,0 +1,36 @@
+package com.sriniketh.prose.core_network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OpenLibrarySearchResponse(
+    val docs: List<OpenLibraryDoc> = emptyList()
+)
+
+@Serializable
+data class OpenLibraryDoc(
+    val key: String,
+    val title: String,
+    val subtitle: String? = null,
+    @SerialName("author_name") val authorName: List<String>? = null,
+    @SerialName("cover_i") val coverId: Int? = null,
+    @SerialName("first_publish_year") val firstPublishYear: Int? = null,
+    @SerialName("number_of_pages_median") val numberOfPagesMedian: Int? = null,
+    val publisher: List<String>? = null,
+    @SerialName("ratings_average") val ratingsAverage: Double? = null,
+    @SerialName("ratings_count") val ratingsCount: Int? = null
+)
+
+@Serializable
+data class OpenLibraryWork(
+    @Serializable(with = WorkDescriptionSerializer::class)
+    val description: WorkDescription? = null
+)
+
+// No @Serializable: Open Library returns `description` as either a bare string or a
+// {type, value} object, so (de)serialization is handled entirely by WorkDescriptionSerializer,
+// applied at the use site on OpenLibraryWork.description.
+data class WorkDescription(
+    val value: String?
+)

--- a/core-network/src/main/java/com/sriniketh/prose/core_network/model/OpenLibraryModels.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/model/OpenLibraryModels.kt
@@ -11,7 +11,7 @@ data class OpenLibrarySearchResponse(
 @Serializable
 data class OpenLibraryDoc(
     val key: String,
-    val title: String,
+    val title: String = "",
     val subtitle: String? = null,
     @SerialName("author_name") val authorName: List<String>? = null,
     @SerialName("cover_i") val coverId: Int? = null,

--- a/core-network/src/main/java/com/sriniketh/prose/core_network/model/WorkDescriptionSerializer.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/model/WorkDescriptionSerializer.kt
@@ -1,0 +1,33 @@
+package com.sriniketh.prose.core_network.model
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+object WorkDescriptionSerializer : KSerializer<WorkDescription> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("WorkDescription", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): WorkDescription {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("WorkDescriptionSerializer can only be used with JSON")
+        return when (val element = jsonDecoder.decodeJsonElement()) {
+            is JsonPrimitive -> WorkDescription(element.contentOrNull)
+            is JsonObject -> WorkDescription((element["value"] as? JsonPrimitive)?.contentOrNull)
+            else -> WorkDescription(null)
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: WorkDescription) {
+        encoder.encodeString(value.value.orEmpty())
+    }
+}

--- a/core-network/src/main/java/com/sriniketh/prose/core_network/model/WorkDescriptionSerializer.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/model/WorkDescriptionSerializer.kt
@@ -1,5 +1,6 @@
 package com.sriniketh.prose.core_network.model
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -27,7 +28,9 @@ object WorkDescriptionSerializer : KSerializer<WorkDescription> {
         }
     }
 
+    @OptIn(ExperimentalSerializationApi::class)
     override fun serialize(encoder: Encoder, value: WorkDescription) {
-        encoder.encodeString(value.value.orEmpty())
+        val text = value.value
+        if (text == null) encoder.encodeNull() else encoder.encodeString(text)
     }
 }

--- a/core-network/src/main/java/com/sriniketh/prose/core_network/retrofit/BooksApi.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/retrofit/BooksApi.kt
@@ -1,23 +1,22 @@
 package com.sriniketh.prose.core_network.retrofit
 
-import com.sriniketh.prose.core_network.model.Volume
-import com.sriniketh.prose.core_network.model.Volumes
+import com.sriniketh.prose.core_network.model.OpenLibrarySearchResponse
+import com.sriniketh.prose.core_network.model.OpenLibraryWork
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface BooksApi {
 
-    @GET("books/v1/volumes")
-    suspend fun volumes(
-        @Query("q") searchQuery: String,
-        @Query("key") apiKey: String,
-        @Query("projection") projection: String
-    ): Volumes
+    @GET("search.json")
+    suspend fun search(
+        @Query("q") query: String,
+        @Query("fields") fields: String,
+        @Query("limit") limit: Int
+    ): OpenLibrarySearchResponse
 
-    @GET("books/v1/volumes/{id}")
-    suspend fun volume(
-        @Path("id") volumeId: String,
-        @Query("key") apiKey: String
-    ): Volume
+    @GET("works/{id}.json")
+    suspend fun work(
+        @Path("id") workId: String
+    ): OpenLibraryWork
 }

--- a/core-network/src/main/java/com/sriniketh/prose/core_network/retrofit/BooksRemoteDataSourceImpl.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/retrofit/BooksRemoteDataSourceImpl.kt
@@ -1,18 +1,29 @@
 package com.sriniketh.prose.core_network.retrofit
 
 import com.sriniketh.prose.core_network.BooksRemoteDataSource
-import com.sriniketh.prose.core_network.BuildConfig
+import com.sriniketh.prose.core_network.mapper.asVolume
+import com.sriniketh.prose.core_network.mapper.asVolumes
 import com.sriniketh.prose.core_network.model.Volume
 import com.sriniketh.prose.core_network.model.Volumes
 import javax.inject.Inject
+
+private const val SEARCH_FIELDS =
+    "key,title,subtitle,author_name,cover_i,first_publish_year," +
+        "number_of_pages_median,publisher,ratings_average,ratings_count"
+private const val SEARCH_LIMIT = 20
 
 class BooksRemoteDataSourceImpl @Inject constructor(
     private val booksApi: BooksApi
 ) : BooksRemoteDataSource {
 
     override suspend fun getVolumes(searchQuery: String): Volumes =
-        booksApi.volumes(searchQuery, BuildConfig.BOOKS_API_KEY, "lite")
+        booksApi.search(searchQuery, SEARCH_FIELDS, SEARCH_LIMIT).asVolumes()
 
-    override suspend fun getVolume(volumeId: String): Volume =
-        booksApi.volume(volumeId, BuildConfig.BOOKS_API_KEY)
+    override suspend fun getVolume(volumeId: String): Volume {
+        val doc = booksApi.search("key:/works/$volumeId", SEARCH_FIELDS, limit = 1)
+            .docs.firstOrNull()
+            ?: throw NoSuchElementException("No work found for id: $volumeId")
+        val description = booksApi.work(volumeId).description?.value
+        return doc.asVolume(description)
+    }
 }

--- a/core-network/src/main/java/com/sriniketh/prose/core_network/retrofit/BooksRemoteDataSourceImpl.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/retrofit/BooksRemoteDataSourceImpl.kt
@@ -5,6 +5,7 @@ import com.sriniketh.prose.core_network.mapper.asVolume
 import com.sriniketh.prose.core_network.mapper.asVolumes
 import com.sriniketh.prose.core_network.model.Volume
 import com.sriniketh.prose.core_network.model.Volumes
+import kotlin.coroutines.cancellation.CancellationException
 import javax.inject.Inject
 
 private const val SEARCH_FIELDS =
@@ -23,7 +24,15 @@ class BooksRemoteDataSourceImpl @Inject constructor(
         val doc = booksApi.search("key:/works/$volumeId", SEARCH_FIELDS, limit = 1)
             .docs.firstOrNull()
             ?: throw NoSuchElementException("No work found for id: $volumeId")
-        val description = booksApi.work(volumeId).description?.value
-        return doc.asVolume(description)
+        return doc.asVolume(fetchDescription(volumeId))
     }
+
+    private suspend fun fetchDescription(volumeId: String): String? =
+        try {
+            booksApi.work(volumeId).description?.value
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (exception: Exception) {
+            null
+        }
 }

--- a/core-network/src/test/java/com/sriniketh/prose/core_network/di/BooksApiJsonTest.kt
+++ b/core-network/src/test/java/com/sriniketh/prose/core_network/di/BooksApiJsonTest.kt
@@ -3,6 +3,7 @@ package com.sriniketh.prose.core_network.di
 import com.sriniketh.prose.core_network.model.OpenLibrarySearchResponse
 import kotlinx.serialization.decodeFromString
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class BooksApiJsonTest {
@@ -50,70 +51,34 @@ class BooksApiJsonTest {
     }
 
     @Test
-    fun `decodes volumes when items omit title and authors`() {
+    fun `decodes docs that omit title, authors, and cover`() {
         val payload = """
             {
-              "kind": "books#volumes",
-              "totalItems": 3,
-              "items": [
+              "numFound": 2,
+              "docs": [
                 {
-                  "id": "complete",
-                  "volumeInfo": {
-                    "title": "Complete Volume",
-                    "authors": ["Author One"]
-                  }
+                  "key": "/works/OL1W",
+                  "title": "Complete",
+                  "author_name": ["Author One"],
+                  "cover_i": 42
                 },
                 {
-                  "id": "missingAuthors",
-                  "volumeInfo": {
-                    "title": "Has Title Only"
-                  }
-                },
-                {
-                  "id": "missingTitleAndAuthors",
-                  "volumeInfo": {
-                    "publisher": "Some Publisher"
-                  }
+                  "key": "/works/OL2W"
                 }
               ]
             }
         """.trimIndent()
 
-        val volumes = booksApiJson.decodeFromString<Volumes>(payload)
+        val response = booksApiJson.decodeFromString<OpenLibrarySearchResponse>(payload)
 
-        assertEquals(3, volumes.items.size)
-        assertEquals(listOf("Author One"), volumes.items[0].volumeInfo.authors)
+        assertEquals(2, response.docs.size)
+        assertEquals("Complete", response.docs[0].title)
+        assertEquals(listOf("Author One"), response.docs[0].authorName)
+        assertEquals(42, response.docs[0].coverId)
 
-        assertEquals("Has Title Only", volumes.items[1].volumeInfo.title)
-        assertEquals(emptyList<String>(), volumes.items[1].volumeInfo.authors)
-
-        assertEquals("", volumes.items[2].volumeInfo.title)
-        assertEquals(emptyList<String>(), volumes.items[2].volumeInfo.authors)
-    }
-
-    @Test
-    fun `decodes imageLinks when thumbnail is omitted`() {
-        val payload = """
-            {
-              "kind": "books#volumes",
-              "totalItems": 1,
-              "items": [
-                {
-                  "id": "noThumbnail",
-                  "volumeInfo": {
-                    "title": "Some Title",
-                    "authors": ["Author One"],
-                    "imageLinks": {
-                      "smallThumbnail": "http://books.google.com/small"
-                    }
-                  }
-                }
-              ]
-            }
-        """.trimIndent()
-
-        val volumes = booksApiJson.decodeFromString<Volumes>(payload)
-
-        assertEquals(null, volumes.items[0].volumeInfo.imageLinks?.thumbnail)
+        assertEquals("/works/OL2W", response.docs[1].key)
+        assertEquals("", response.docs[1].title)
+        assertNull(response.docs[1].authorName)
+        assertNull(response.docs[1].coverId)
     }
 }

--- a/core-network/src/test/java/com/sriniketh/prose/core_network/di/BooksApiJsonTest.kt
+++ b/core-network/src/test/java/com/sriniketh/prose/core_network/di/BooksApiJsonTest.kt
@@ -1,6 +1,6 @@
 package com.sriniketh.prose.core_network.di
 
-import com.sriniketh.prose.core_network.model.Volumes
+import com.sriniketh.prose.core_network.model.OpenLibrarySearchResponse
 import kotlinx.serialization.decodeFromString
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -8,56 +8,44 @@ import org.junit.Test
 class BooksApiJsonTest {
 
     @Test
-    fun `decodes google books payload while ignoring unknown keys`() {
+    fun `decodes open library search payload while ignoring unknown keys`() {
         val payload = """
             {
-              "kind": "books#volumes",
-              "totalItems": 1,
-              "items": [
+              "numFound": 1,
+              "start": 0,
+              "docs": [
                 {
-                  "kind": "books#volume",
-                  "id": "someId",
-                  "etag": "abc123",
-                  "selfLink": "https://www.googleapis.com/books/v1/volumes/someId",
-                  "volumeInfo": {
-                    "title": "Some Title",
-                    "subtitle": "Some Subtitle",
-                    "authors": ["Author One"],
-                    "publisher": "Some Publisher",
-                    "publishedDate": "2020",
-                    "description": "A description",
-                    "industryIdentifiers": [
-                      {"type": "ISBN_13", "identifier": "9781234567897"}
-                    ],
-                    "pageCount": 321,
-                    "categories": ["Fiction"],
-                    "averageRating": 4.5,
-                    "ratingsCount": 12,
-                    "imageLinks": {
-                      "smallThumbnail": "http://books.google.com/small",
-                      "thumbnail": "http://books.google.com/thumb"
-                    },
-                    "language": "en",
-                    "previewLink": "http://books.google.com/preview"
-                  },
-                  "saleInfo": {"country": "US", "saleability": "NOT_FOR_SALE"},
-                  "accessInfo": {"country": "US", "viewability": "PARTIAL"}
+                  "key": "/works/OL27482W",
+                  "type": "work",
+                  "title": "The Hobbit",
+                  "subtitle": "or There and Back Again",
+                  "author_name": ["J.R.R. Tolkien"],
+                  "cover_i": 14627509,
+                  "first_publish_year": 1937,
+                  "number_of_pages_median": 310,
+                  "publisher": ["George Allen & Unwin", "Houghton Mifflin"],
+                  "ratings_average": 4.3,
+                  "ratings_count": 285,
+                  "ia": ["hobbitorthereand0000tolk"],
+                  "language": ["eng"]
                 }
               ]
             }
         """.trimIndent()
 
-        val volumes = booksApiJson.decodeFromString<Volumes>(payload)
+        val response = booksApiJson.decodeFromString<OpenLibrarySearchResponse>(payload)
 
-        assertEquals(1, volumes.items.size)
-        val volumeInfo = volumes.items[0].volumeInfo
-        assertEquals("someId", volumes.items[0].id)
-        assertEquals("Some Title", volumeInfo.title)
-        assertEquals("Some Subtitle", volumeInfo.subtitle)
-        assertEquals("Author One", volumeInfo.authors[0])
-        assertEquals(321, volumeInfo.pageCount)
-        assertEquals(4.5, volumeInfo.averageRating)
-        assertEquals(12, volumeInfo.ratingsCount)
-        assertEquals("http://books.google.com/thumb", volumeInfo.imageLinks?.thumbnail)
+        assertEquals(1, response.docs.size)
+        val doc = response.docs[0]
+        assertEquals("/works/OL27482W", doc.key)
+        assertEquals("The Hobbit", doc.title)
+        assertEquals("or There and Back Again", doc.subtitle)
+        assertEquals(listOf("J.R.R. Tolkien"), doc.authorName)
+        assertEquals(14627509, doc.coverId)
+        assertEquals(1937, doc.firstPublishYear)
+        assertEquals(310, doc.numberOfPagesMedian)
+        assertEquals(listOf("George Allen & Unwin", "Houghton Mifflin"), doc.publisher)
+        assertEquals(4.3, doc.ratingsAverage)
+        assertEquals(285, doc.ratingsCount)
     }
 }

--- a/core-network/src/test/java/com/sriniketh/prose/core_network/mapper/OpenLibraryMappersTest.kt
+++ b/core-network/src/test/java/com/sriniketh/prose/core_network/mapper/OpenLibraryMappersTest.kt
@@ -1,0 +1,84 @@
+package com.sriniketh.prose.core_network.mapper
+
+import com.sriniketh.prose.core_network.model.OpenLibraryDoc
+import com.sriniketh.prose.core_network.model.OpenLibrarySearchResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class OpenLibraryMappersTest {
+
+    private fun fullDoc() = OpenLibraryDoc(
+        key = "/works/OL1W",
+        title = "Title",
+        subtitle = "Sub",
+        authorName = listOf("Author A", "Author B"),
+        coverId = 123,
+        firstPublishYear = 1999,
+        numberOfPagesMedian = 321,
+        publisher = listOf("Pub One", "Pub Two"),
+        ratingsAverage = 4.5,
+        ratingsCount = 100
+    )
+
+    @Test
+    fun `maps a search response to volumes preserving order`() {
+        val response = OpenLibrarySearchResponse(
+            docs = listOf(
+                fullDoc(),
+                fullDoc().copy(key = "/works/OL2W", title = "Second")
+            )
+        )
+
+        val volumes = response.asVolumes()
+
+        assertEquals(2, volumes.items.size)
+        assertEquals("OL1W", volumes.items[0].id)
+        assertEquals("OL2W", volumes.items[1].id)
+        assertEquals("Second", volumes.items[1].volumeInfo.title)
+    }
+
+    @Test
+    fun `maps every field of a doc into volume info`() {
+        val volume = fullDoc().asVolume()
+        val info = volume.volumeInfo
+
+        assertEquals("OL1W", volume.id)
+        assertEquals("Title", info.title)
+        assertEquals("Sub", info.subtitle)
+        assertEquals(listOf("Author A", "Author B"), info.authors)
+        assertEquals("https://covers.openlibrary.org/b/id/123-M.jpg", info.imageLinks?.thumbnail)
+        assertEquals("Pub One", info.publisher)
+        assertEquals("1999", info.publishedDate)
+        assertEquals(321, info.pageCount)
+        assertEquals(4.5, info.averageRating!!, 0.0)
+        assertEquals(100, info.ratingsCount)
+    }
+
+    @Test
+    fun `search mapping leaves description null`() {
+        assertNull(fullDoc().asVolume().volumeInfo.description)
+    }
+
+    @Test
+    fun `asVolume merges an explicit description`() {
+        assertEquals("My description", fullDoc().asVolume("My description").volumeInfo.description)
+    }
+
+    @Test
+    fun `null cover id yields null image links`() {
+        assertNull(fullDoc().copy(coverId = null).asVolume().volumeInfo.imageLinks)
+    }
+
+    @Test
+    fun `null author name maps to empty list`() {
+        assertEquals(emptyList<String>(), fullDoc().copy(authorName = null).asVolume().volumeInfo.authors)
+    }
+
+    @Test
+    fun `null publisher and year map to null`() {
+        val info = fullDoc().copy(publisher = null, firstPublishYear = null).asVolume().volumeInfo
+        assertNull(info.publisher)
+        assertNull(info.publishedDate)
+    }
+}

--- a/core-network/src/test/java/com/sriniketh/prose/core_network/model/WorkDescriptionSerializerTest.kt
+++ b/core-network/src/test/java/com/sriniketh/prose/core_network/model/WorkDescriptionSerializerTest.kt
@@ -1,0 +1,38 @@
+package com.sriniketh.prose.core_network.model
+
+import com.sriniketh.prose.core_network.di.booksApiJson
+import kotlinx.serialization.decodeFromString
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class WorkDescriptionSerializerTest {
+
+    @Test
+    fun `parses description given as a plain string`() {
+        val work = booksApiJson.decodeFromString<OpenLibraryWork>(
+            """{"description":"A great book"}"""
+        )
+        assertEquals("A great book", work.description?.value)
+    }
+
+    @Test
+    fun `parses description given as a typed object`() {
+        val work = booksApiJson.decodeFromString<OpenLibraryWork>(
+            """{"description":{"type":"/type/text","value":"A great book"}}"""
+        )
+        assertEquals("A great book", work.description?.value)
+    }
+
+    @Test
+    fun `leaves description null when field is absent`() {
+        val work = booksApiJson.decodeFromString<OpenLibraryWork>("""{}""")
+        assertNull(work.description)
+    }
+
+    @Test
+    fun `leaves description null when field is json null`() {
+        val work = booksApiJson.decodeFromString<OpenLibraryWork>("""{"description":null}""")
+        assertNull(work.description)
+    }
+}

--- a/core-network/src/test/java/com/sriniketh/prose/core_network/model/WorkDescriptionSerializerTest.kt
+++ b/core-network/src/test/java/com/sriniketh/prose/core_network/model/WorkDescriptionSerializerTest.kt
@@ -2,6 +2,7 @@ package com.sriniketh.prose.core_network.model
 
 import com.sriniketh.prose.core_network.di.booksApiJson
 import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -34,5 +35,17 @@ class WorkDescriptionSerializerTest {
     fun `leaves description null when field is json null`() {
         val work = booksApiJson.decodeFromString<OpenLibraryWork>("""{"description":null}""")
         assertNull(work.description)
+    }
+
+    @Test
+    fun `encodes a present description value as a json string`() {
+        val json = booksApiJson.encodeToString(OpenLibraryWork(WorkDescription("A great book")))
+        assertEquals("""{"description":"A great book"}""", json)
+    }
+
+    @Test
+    fun `encodes a null description value as json null`() {
+        val json = booksApiJson.encodeToString(OpenLibraryWork(WorkDescription(null)))
+        assertEquals("""{"description":null}""", json)
     }
 }

--- a/core-network/src/test/java/com/sriniketh/prose/core_network/retrofit/BooksRemoteDataSourceImplTest.kt
+++ b/core-network/src/test/java/com/sriniketh/prose/core_network/retrofit/BooksRemoteDataSourceImplTest.kt
@@ -1,6 +1,5 @@
 package com.sriniketh.prose.core_network.retrofit
 
-import com.sriniketh.prose.core_network.BuildConfig
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -10,76 +9,51 @@ import org.junit.Test
 class BooksRemoteDataSourceImplTest {
 
     private lateinit var booksApi: FakeBooksApi
-    private lateinit var dataSourceImpl: BooksRemoteDataSourceImpl
+    private lateinit var dataSource: BooksRemoteDataSourceImpl
 
     @Before
     fun setup() {
         booksApi = FakeBooksApi()
-        dataSourceImpl = BooksRemoteDataSourceImpl(booksApi)
+        dataSource = BooksRemoteDataSourceImpl(booksApi)
     }
 
     @Test
-    fun `getVolumes returns volumes for given searchQuery`() = runTest {
+    fun `getVolumes searches and maps results without description`() = runTest {
         assertNull(booksApi.searchQueryPassed)
-        assertNull(booksApi.apiKeyPassed)
-        assertNull(booksApi.projectionPassed)
-        val volumes = dataSourceImpl.getVolumes("some search query")
+
+        val volumes = dataSource.getVolumes("some search query")
+
         assertEquals("some search query", booksApi.searchQueryPassed)
-        assertEquals(BuildConfig.BOOKS_API_KEY, booksApi.apiKeyPassed)
-        assertEquals("lite", booksApi.projectionPassed)
         assertEquals(2, volumes.items.size)
 
-        val volume1 = volumes.items[0]
-        val volume1VolumeInfo = volume1.volumeInfo
-        assertEquals("someId1", volume1.id)
-        assertEquals("title 1", volume1VolumeInfo.title)
-        assertEquals("subtitle 1", volume1VolumeInfo.subtitle)
-        assertEquals("description 1", volume1VolumeInfo.description)
-        assertEquals("author 1", volume1VolumeInfo.authors[0])
-        assertEquals("author 2", volume1VolumeInfo.authors[1])
-        assertEquals("thumbnail 1", volume1VolumeInfo.imageLinks?.thumbnail)
-        assertEquals("publisher 1", volume1VolumeInfo.publisher)
-        assertEquals("published date 1", volume1VolumeInfo.publishedDate)
-        assertEquals(100, volume1VolumeInfo.pageCount)
-        assertEquals(4.5, volume1VolumeInfo.averageRating)
-        assertEquals(4500, volume1VolumeInfo.ratingsCount)
+        val first = volumes.items[0]
+        assertEquals("OL1W", first.id)
+        assertEquals("title 1", first.volumeInfo.title)
+        assertEquals("subtitle 1", first.volumeInfo.subtitle)
+        assertEquals(listOf("author 1", "author 2"), first.volumeInfo.authors)
+        assertEquals("https://covers.openlibrary.org/b/id/111-M.jpg", first.volumeInfo.imageLinks?.thumbnail)
+        assertEquals("publisher 1", first.volumeInfo.publisher)
+        assertEquals("2001", first.volumeInfo.publishedDate)
+        assertEquals(100, first.volumeInfo.pageCount)
+        assertEquals(4.5, first.volumeInfo.averageRating!!, 0.0)
+        assertEquals(4500, first.volumeInfo.ratingsCount)
+        assertNull(first.volumeInfo.description)
 
-        val volume2 = volumes.items[1]
-        val volume2VolumeInfo = volume2.volumeInfo
-        assertEquals("someId2", volume2.id)
-        assertEquals("title 2", volume2VolumeInfo.title)
-        assertEquals("subtitle 2", volume2VolumeInfo.subtitle)
-        assertEquals("description 2", volume2VolumeInfo.description)
-        assertEquals("author 1", volume2VolumeInfo.authors[0])
-        assertEquals("author 2", volume2VolumeInfo.authors[1])
-        assertEquals("thumbnail 2", volume2VolumeInfo.imageLinks?.thumbnail)
-        assertEquals("publisher 2", volume2VolumeInfo.publisher)
-        assertEquals("published date 2", volume2VolumeInfo.publishedDate)
-        assertEquals(250, volume2VolumeInfo.pageCount)
-        assertEquals(4.3, volume2VolumeInfo.averageRating)
-        assertEquals(500, volume2VolumeInfo.ratingsCount)
+        assertEquals("OL2W", volumes.items[1].id)
     }
 
     @Test
-    fun `getVolume returns volume for given volumeId`() = runTest {
-        assertNull(booksApi.apiKeyPassed)
-        assertNull(booksApi.volumeIdPassed)
-        val volume = dataSourceImpl.getVolume("some volume id")
-        assertEquals(BuildConfig.BOOKS_API_KEY, booksApi.apiKeyPassed)
-        assertEquals("some volume id", booksApi.volumeIdPassed)
+    fun `getVolume searches by key and merges the work description`() = runTest {
+        assertNull(booksApi.searchQueryPassed)
+        assertNull(booksApi.workIdPassed)
 
-        assertEquals("someId1", volume.id)
-        val volume1VolumeInfo = volume.volumeInfo
-        assertEquals("title 1", volume1VolumeInfo.title)
-        assertEquals("subtitle 1", volume1VolumeInfo.subtitle)
-        assertEquals("description 1", volume1VolumeInfo.description)
-        assertEquals("author 1", volume1VolumeInfo.authors[0])
-        assertEquals("author 2", volume1VolumeInfo.authors[1])
-        assertEquals("thumbnail 1", volume1VolumeInfo.imageLinks?.thumbnail)
-        assertEquals("publisher 1", volume1VolumeInfo.publisher)
-        assertEquals("published date 1", volume1VolumeInfo.publishedDate)
-        assertEquals(100, volume1VolumeInfo.pageCount)
-        assertEquals(4.5, volume1VolumeInfo.averageRating)
-        assertEquals(4500, volume1VolumeInfo.ratingsCount)
+        val volume = dataSource.getVolume("OL1W")
+
+        assertEquals("key:/works/OL1W", booksApi.searchQueryPassed)
+        assertEquals("OL1W", booksApi.workIdPassed)
+
+        assertEquals("OL1W", volume.id)
+        assertEquals("title 1", volume.volumeInfo.title)
+        assertEquals("work description", volume.volumeInfo.description)
     }
 }

--- a/core-network/src/test/java/com/sriniketh/prose/core_network/retrofit/BooksRemoteDataSourceImplTest.kt
+++ b/core-network/src/test/java/com/sriniketh/prose/core_network/retrofit/BooksRemoteDataSourceImplTest.kt
@@ -56,4 +56,23 @@ class BooksRemoteDataSourceImplTest {
         assertEquals("title 1", volume.volumeInfo.title)
         assertEquals("work description", volume.volumeInfo.description)
     }
+
+    @Test
+    fun `getVolume returns metadata with null description when the work fetch fails`() = runTest {
+        booksApi.shouldWorkThrow = true
+
+        val volume = dataSource.getVolume("OL1W")
+
+        assertEquals("OL1W", volume.id)
+        assertEquals("title 1", volume.volumeInfo.title)
+        assertEquals("OL1W", booksApi.workIdPassed)
+        assertNull(volume.volumeInfo.description)
+    }
+
+    @Test(expected = NoSuchElementException::class)
+    fun `getVolume throws when no work matches the id`() = runTest {
+        booksApi.shouldReturnNoDocs = true
+
+        dataSource.getVolume("OL404W")
+    }
 }

--- a/core-network/src/test/java/com/sriniketh/prose/core_network/retrofit/FakeBooksApi.kt
+++ b/core-network/src/test/java/com/sriniketh/prose/core_network/retrofit/FakeBooksApi.kt
@@ -4,12 +4,14 @@ import com.sriniketh.prose.core_network.model.OpenLibraryDoc
 import com.sriniketh.prose.core_network.model.OpenLibrarySearchResponse
 import com.sriniketh.prose.core_network.model.OpenLibraryWork
 import com.sriniketh.prose.core_network.model.WorkDescription
+import java.io.IOException
 
 class FakeBooksApi : BooksApi {
 
     var searchQueryPassed: String? = null
     var fieldsPassed: String? = null
     var limitPassed: Int? = null
+    var shouldReturnNoDocs = false
     override suspend fun search(
         query: String,
         fields: String,
@@ -18,12 +20,15 @@ class FakeBooksApi : BooksApi {
         searchQueryPassed = query
         fieldsPassed = fields
         limitPassed = limit
-        return OpenLibrarySearchResponse(docs = listOf(doc1(), doc2()))
+        val docs = if (shouldReturnNoDocs) emptyList() else listOf(doc1(), doc2())
+        return OpenLibrarySearchResponse(docs = docs)
     }
 
     var workIdPassed: String? = null
+    var shouldWorkThrow = false
     override suspend fun work(workId: String): OpenLibraryWork {
         workIdPassed = workId
+        if (shouldWorkThrow) throw IOException("work endpoint failed")
         return OpenLibraryWork(description = WorkDescription("work description"))
     }
 

--- a/core-network/src/test/java/com/sriniketh/prose/core_network/retrofit/FakeBooksApi.kt
+++ b/core-network/src/test/java/com/sriniketh/prose/core_network/retrofit/FakeBooksApi.kt
@@ -1,72 +1,55 @@
 package com.sriniketh.prose.core_network.retrofit
 
-import com.sriniketh.prose.core_network.model.ImageLinks
-import com.sriniketh.prose.core_network.model.Volume
-import com.sriniketh.prose.core_network.model.VolumeInfo
-import com.sriniketh.prose.core_network.model.Volumes
+import com.sriniketh.prose.core_network.model.OpenLibraryDoc
+import com.sriniketh.prose.core_network.model.OpenLibrarySearchResponse
+import com.sriniketh.prose.core_network.model.OpenLibraryWork
+import com.sriniketh.prose.core_network.model.WorkDescription
 
 class FakeBooksApi : BooksApi {
 
     var searchQueryPassed: String? = null
-    var apiKeyPassed: String? = null
-    var projectionPassed: String? = null
-    override suspend fun volumes(searchQuery: String, apiKey: String, projection: String): Volumes {
-        searchQueryPassed = searchQuery
-        apiKeyPassed = apiKey
-        projectionPassed = projection
-        return Volumes(items = listOf(volume1(), volume2()))
+    var fieldsPassed: String? = null
+    var limitPassed: Int? = null
+    override suspend fun search(
+        query: String,
+        fields: String,
+        limit: Int
+    ): OpenLibrarySearchResponse {
+        searchQueryPassed = query
+        fieldsPassed = fields
+        limitPassed = limit
+        return OpenLibrarySearchResponse(docs = listOf(doc1(), doc2()))
     }
 
-    var volumeIdPassed: String? = null
-    override suspend fun volume(volumeId: String, apiKey: String): Volume {
-        volumeIdPassed = volumeId
-        apiKeyPassed = apiKey
-        return volume1()
+    var workIdPassed: String? = null
+    override suspend fun work(workId: String): OpenLibraryWork {
+        workIdPassed = workId
+        return OpenLibraryWork(description = WorkDescription("work description"))
     }
 
-    private fun volume1() = Volume(
-        id = "someId1", volumeInfo = VolumeInfo(
-            title = "title 1",
-            subtitle = "subtitle 1",
-            description = "description 1",
-            authors = listOf(
-                "author 1", "author 2"
-            ),
-            imageLinks = ImageLinks(
-                thumbnail = "thumbnail 1",
-                smallThumbnail = null,
-                small = null,
-                medium = null,
-                large = null
-            ),
-            publisher = "publisher 1",
-            publishedDate = "published date 1",
-            pageCount = 100,
-            averageRating = 4.5,
-            ratingsCount = 4500
-        )
+    private fun doc1() = OpenLibraryDoc(
+        key = "/works/OL1W",
+        title = "title 1",
+        subtitle = "subtitle 1",
+        authorName = listOf("author 1", "author 2"),
+        coverId = 111,
+        firstPublishYear = 2001,
+        numberOfPagesMedian = 100,
+        publisher = listOf("publisher 1"),
+        ratingsAverage = 4.5,
+        ratingsCount = 4500
     )
 
-    private fun volume2() = Volume(
-        id = "someId2", volumeInfo = VolumeInfo(
-            title = "title 2",
-            subtitle = "subtitle 2",
-            description = "description 2",
-            authors = listOf(
-                "author 1", "author 2"
-            ),
-            imageLinks = ImageLinks(
-                thumbnail = "thumbnail 2",
-                smallThumbnail = null,
-                small = null,
-                medium = null,
-                large = null
-            ),
-            publisher = "publisher 2",
-            publishedDate = "published date 2",
-            pageCount = 250,
-            averageRating = 4.3,
-            ratingsCount = 500
-        )
+    private fun doc2() = OpenLibraryDoc(
+        key = "/works/OL2W",
+        title = "title 2",
+        subtitle = "subtitle 2",
+        authorName = listOf("author 1", "author 2"),
+        coverId = 222,
+        firstPublishYear = 2002,
+        numberOfPagesMedian = 250,
+        publisher = listOf("publisher 2"),
+        ratingsAverage = 4.3,
+        ratingsCount = 500
     )
 }


### PR DESCRIPTION
## Summary

Migrates `core-network` from the Google Books API to the Open Library API. The `Volumes` / `Volume` / `VolumeInfo` / `ImageLinks` contract consumed by `core-data` and the feature modules is kept byte-for-byte identical — no Room migration, no domain/UI/feature changes. Builds on the completed Moshi → kotlinx.serialization migration.

- **Wire models + serializer** — OL `@Serializable` models plus a custom `KSerializer` for the polymorphic `description` field (bare string *or* `{"type":"/type/text","value":"…"}` object).
- **Mappers** — OL → `Volumes`/`Volume`: strip the `/works/` prefix from the id (slash-free Room PK / nav arg), build the cover URL from `cover_i`, collapse the publisher array to its first element, `first_publish_year` → string.
- **Retrofit + data source** — `BooksApi` repointed at `search.json` + `works/{id}.json`; `getVolume` merges two calls (search-by-key metadata + the works description). A failed works call yields a null description rather than failing the whole detail. No API key.
- **Hilt** — base URL → `https://openlibrary.org/`; `User-Agent` = `Prose/<versionName>` (per Open Library guidance), injected via a `@Named("userAgent")` binding the **app** module provides from `BuildConfig.VERSION_NAME` (app's `versionName` stays the single source of truth — no hardcoded version in `core-network`).
- **Drop API-key scaffolding** — removes the `apikey.properties` loading + `BOOKS_API_KEY` build-config field from `core-network`, the apikey creation steps from CI, and the API-key section from `AGENTS.md`.

**Scope:** `core-network/**` + `AGENTS.md`, a one-line `@Provides` in the app's existing `AppModule` (User-Agent), and removal of the apikey steps in `.github/workflows/build.yml`. Zero changes under `core-db`, `core-models`, `core-data`, or any `feature-*` module — the downstream contract is preserved.

## Test Plan

- [x] `:core-network` unit — 16/16 (serializer string/object/null/absent; mapper field + null edges; data-source two-call merge, failed-description fallback, no-matching-work throw; OL search-payload decode with unknown-key tolerance).
- [x] `./gradlew :app:assembleDebug` — green; validates the cross-module Hilt graph (`core-network` consumes the app-provided `@Named("userAgent")`).
- [x] `./gradlew test` + `assembleDebug` — green; `core-data`/`core-db`/`feature-*` pass unchanged, proving the contract held.
- [x] On-device smoke (emulator, API 34): search renders titles/authors/covers; detail shows title/author/publisher/description/cover; save-to-shelf persists; reopening confirms the `OLxxxW` id round-trips through navigation + Room with no slash issues.

> Out of scope: smoke-testing surfaced a pre-existing search-as-you-type race in `feature-searchbooks` (a slower partial-query response can overwrite newer results) — fixed in #97, not touched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
