### PR TITLE
test(feature-viewhighlights): stabilize flaky OnExportHighlights tests

### DIFF
--- a/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModelTest.kt
+++ b/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModelTest.kt
@@ -250,6 +250,7 @@ class ViewHighlightsViewModelTest {
     fun `when OnExportHighlights action succeeds then emits share effect and clears loading`() = runTest {
         viewModel.effects.test {
             viewModel.processAction(ViewHighlightsAction.OnExportHighlights("test-book-id"))
+            testScheduler.advanceUntilIdle()
 
             val effect = awaitItem()
             assertTrue(effect is ViewHighlightsEffect.ShareHighlights)
@@ -265,6 +266,7 @@ class ViewHighlightsViewModelTest {
 
         viewModel.effects.test {
             viewModel.processAction(ViewHighlightsAction.OnExportHighlights("test-book-id"))
+            testScheduler.advanceUntilIdle()
 
             assertEquals(
                 ViewHighlightsEffect.ShowMessage(R.string.export_error_message),


### PR DESCRIPTION
## Summary

The two `OnExportHighlights` effect tests in `ViewHighlightsViewModelTest` await a Turbine emission **without advancing the test scheduler**. The export runs on `viewModelScope.launch` (= `Dispatchers.Main` = `StandardTestDispatcher`), so the coroutine only runs once the scheduler is advanced. Without an explicit advance, the tests lean on Turbine's **real-time** await timeout to give the coroutine a chance to run — which times out (`TurbineTimeoutCancellationException`) on slower CI runners.

`main` has been **masking** this via Gradle build-cache reuse (the test task is served from cache and not re-executed). It surfaces whenever something invalidates `feature-viewhighlights`' test cache and forces a real run on CI.

Fix: call `testScheduler.advanceUntilIdle()` after dispatching the action and before `awaitItem()`, matching the sibling tests in the same class. The launched coroutine now runs deterministically under virtual time, removing the real-time dependency.

## Test Plan
- [x] `./gradlew :feature-viewhighlights:testDebugUnitTest --rerun-tasks` — green, 3× in a row (was a timing-dependent timeout before)
- [x] Test-only change; no production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)