### PR TITLE
fix(core-network): tolerate volumes missing title/authors/thumbnail

### DIFF
--- a/core-network/src/main/java/com/sriniketh/prose/core_network/model/Volumes.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/model/Volumes.kt
@@ -15,10 +15,10 @@ data class Volume(
 
 @Serializable
 data class VolumeInfo(
-    val title: String,
+    val title: String = "",
     val subtitle: String? = null,
     val description: String? = null,
-    val authors: List<String>,
+    val authors: List<String> = emptyList(),
     val imageLinks: ImageLinks? = null,
     val publisher: String? = null,
     val publishedDate: String? = null,
@@ -29,7 +29,7 @@ data class VolumeInfo(
 
 @Serializable
 data class ImageLinks(
-    val thumbnail: String,
+    val thumbnail: String? = null,
     val smallThumbnail: String? = null,
     val small: String? = null,
     val medium: String? = null,

--- a/core-network/src/test/java/com/sriniketh/prose/core_network/di/BooksApiJsonTest.kt
+++ b/core-network/src/test/java/com/sriniketh/prose/core_network/di/BooksApiJsonTest.kt
@@ -60,4 +60,72 @@ class BooksApiJsonTest {
         assertEquals(12, volumeInfo.ratingsCount)
         assertEquals("http://books.google.com/thumb", volumeInfo.imageLinks?.thumbnail)
     }
+
+    @Test
+    fun `decodes volumes when items omit title and authors`() {
+        val payload = """
+            {
+              "kind": "books#volumes",
+              "totalItems": 3,
+              "items": [
+                {
+                  "id": "complete",
+                  "volumeInfo": {
+                    "title": "Complete Volume",
+                    "authors": ["Author One"]
+                  }
+                },
+                {
+                  "id": "missingAuthors",
+                  "volumeInfo": {
+                    "title": "Has Title Only"
+                  }
+                },
+                {
+                  "id": "missingTitleAndAuthors",
+                  "volumeInfo": {
+                    "publisher": "Some Publisher"
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val volumes = booksApiJson.decodeFromString<Volumes>(payload)
+
+        assertEquals(3, volumes.items.size)
+        assertEquals(listOf("Author One"), volumes.items[0].volumeInfo.authors)
+
+        assertEquals("Has Title Only", volumes.items[1].volumeInfo.title)
+        assertEquals(emptyList<String>(), volumes.items[1].volumeInfo.authors)
+
+        assertEquals("", volumes.items[2].volumeInfo.title)
+        assertEquals(emptyList<String>(), volumes.items[2].volumeInfo.authors)
+    }
+
+    @Test
+    fun `decodes imageLinks when thumbnail is omitted`() {
+        val payload = """
+            {
+              "kind": "books#volumes",
+              "totalItems": 1,
+              "items": [
+                {
+                  "id": "noThumbnail",
+                  "volumeInfo": {
+                    "title": "Some Title",
+                    "authors": ["Author One"],
+                    "imageLinks": {
+                      "smallThumbnail": "http://books.google.com/small"
+                    }
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val volumes = booksApiJson.decodeFromString<Volumes>(payload)
+
+        assertEquals(null, volumes.items[0].volumeInfo.imageLinks?.thumbnail)
+    }
 }


### PR DESCRIPTION
## Problem
Most book searches (e.g. `harry`, `harry potter`) show an error snackbar and return zero results; a few (e.g. `hobbit`) work.

## Root cause
`VolumeInfo.title`, `VolumeInfo.authors`, and `ImageLinks.thumbnail` are declared required (non-null, no default), but the Google Books API does not guarantee them — many catalog volumes omit `authors`, some omit `title`. kotlinx.serialization fails the *entire* response when any one item lacks a required field, so the whole search returns `Result.failure` → error effect. A live probe of `q=harry` returns items missing `authors` for both `projection=lite` and `projection=full`, so it is real catalog data, not the projection.

This is a longstanding latent bug, not a migration regression: the pre-migration Moshi build fails identically (`JsonDataException: Required value 'authors' missing`). Searches that happened to return only fully-populated top results (`hobbit`) masked it.

## Fix
Give the omittable fields defaults so missing fields deserialize instead of throwing:

| field | change | rationale |
|---|---|---|
| `VolumeInfo.title` | `String = ""` | kept non-null — domain `BookInfo.title` is non-null and the transformer assigns it directly |
| `VolumeInfo.authors` | `List<String> = emptyList()` | |
| `ImageLinks.thumbnail` | `String? = null` | domain `thumbnailLink` is nullable; transformer maps `imageLinks?.thumbnail` |

`VolumeInfo.asBookInfo()` maps these straight through and already tolerates an empty authors list / null thumbnail, so no transformer change is needed.

## Testing
- Added regression tests in `BooksApiJsonTest` decoding a payload whose items omit `title`/`authors`, and an `imageLinks` omitting `thumbnail` (both throw `MissingFieldException` before the fix, pass after).
- Full unit suite green (`./gradlew test`).
- On-device (Pixel_8, API 34): `harry potter` now returns results with no error snackbar and no `MissingFieldException` in logcat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)