### PR TITLE
perf: Compose recomposition Tier-1 hot-path fixes

### DIFF
--- a/core-data/src/main/java/com/sriniketh/core_data/HighlightsRepository.kt
+++ b/core-data/src/main/java/com/sriniketh/core_data/HighlightsRepository.kt
@@ -7,5 +7,5 @@ interface HighlightsRepository {
     suspend fun insertHighlightIntoDb(highlight: Highlight): Result<Unit>
     suspend fun loadHighlightFromDb(highlightId: String): Result<Highlight>
     fun getAllHighlightsForBookFromDb(bookId: String): Flow<Result<List<Highlight>>>
-    suspend fun deleteHighlightFromDb(highlight: Highlight): Result<Unit>
+    suspend fun deleteHighlightFromDb(highlightId: String): Result<Unit>
 }

--- a/core-data/src/main/java/com/sriniketh/core_data/HighlightsRepositoryImpl.kt
+++ b/core-data/src/main/java/com/sriniketh/core_data/HighlightsRepositoryImpl.kt
@@ -46,9 +46,9 @@ class HighlightsRepositoryImpl @Inject constructor(
                 emit(Result.failure(exception))
             }
 
-    override suspend fun deleteHighlightFromDb(highlight: Highlight): Result<Unit> =
+    override suspend fun deleteHighlightFromDb(highlightId: String): Result<Unit> =
         try {
-            localHighlightsDataSource.deleteHighlight(highlight.asHighlightEntity())
+            localHighlightsDataSource.deleteHighlightById(highlightId)
             Result.success(Unit)
         } catch (exception: Exception) {
             Timber.e(exception)

--- a/core-data/src/main/java/com/sriniketh/core_data/usecases/DeleteHighlightUseCase.kt
+++ b/core-data/src/main/java/com/sriniketh/core_data/usecases/DeleteHighlightUseCase.kt
@@ -1,11 +1,10 @@
 package com.sriniketh.core_data.usecases
 
 import com.sriniketh.core_data.HighlightsRepository
-import com.sriniketh.core_models.book.Highlight
 import javax.inject.Inject
 
 class DeleteHighlightUseCase @Inject constructor(
     private val highlightsRepository: HighlightsRepository
 ) {
-    suspend operator fun invoke(highlight: Highlight): Result<Unit> = highlightsRepository.deleteHighlightFromDb(highlight)
+    suspend operator fun invoke(highlightId: String): Result<Unit> = highlightsRepository.deleteHighlightFromDb(highlightId)
 }

--- a/core-data/src/test/java/com/sriniketh/core_data/HighlightsRepositoryImplTest.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/HighlightsRepositoryImplTest.kt
@@ -131,29 +131,18 @@ class HighlightsRepositoryImplTest {
     @Test
     fun `deleteHighlightFromDb returns success result when highlight is deleted from db`() =
         runTest {
-            val highlight = Highlight(
-                id = "possim", bookId = "eius", text = "ignota", savedOnTimestamp = "diam"
-            )
-            val highlightEntity = HighlightEntity(
-                id = "possim", bookId = "eius", text = "ignota", savedOnTimestamp = "diam"
-            )
-
             highlightDao.shouldDeleteHighlightThrowException = false
-            val result = highlightsRepositoryImpl.deleteHighlightFromDb(highlight)
+            val result = highlightsRepositoryImpl.deleteHighlightFromDb("possim")
             assertTrue(result.isSuccess)
             assertEquals(Unit, result.getOrNull())
-            assertEquals(highlightEntity, highlightDao.deletedHighlightEntity)
+            assertEquals("possim", highlightDao.deletedHighlightId)
         }
 
     @Test
     fun `deleteHighlightFromDb returns failure result when exception occurs during deletion`() =
         runTest {
-            val highlight = Highlight(
-                id = "possim", bookId = "eius", text = "ignota", savedOnTimestamp = "diam"
-            )
-
             highlightDao.shouldDeleteHighlightThrowException = true
-            val result = highlightsRepositoryImpl.deleteHighlightFromDb(highlight)
+            val result = highlightsRepositoryImpl.deleteHighlightFromDb("possim")
             assertTrue(result.isFailure)
             val exception = result.exceptionOrNull()
             assertTrue(exception is RuntimeException)

--- a/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeHighlightDao.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeHighlightDao.kt
@@ -39,12 +39,12 @@ class FakeHighlightDao : HighlightDao {
         return flowOf(highlightsInDb)
     }
 
-    var deletedHighlightEntity: HighlightEntity? = null
+    var deletedHighlightId: String? = null
     var shouldDeleteHighlightThrowException = false
-    override suspend fun deleteHighlight(highlight: HighlightEntity) {
+    override suspend fun deleteHighlightById(id: String) {
         if (shouldDeleteHighlightThrowException) {
             throw RuntimeException("some error deleting highlight")
         }
-        deletedHighlightEntity = highlight
+        deletedHighlightId = id
     }
 }

--- a/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeHighlightsRepository.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeHighlightsRepository.kt
@@ -13,7 +13,7 @@ class FakeHighlightsRepository : HighlightsRepository {
     var shouldDeleteHighlightFromDbThrowException = false
 
     var insertedHighlight: Highlight? = null
-    var deletedHighlight: Highlight? = null
+    var deletedHighlightId: String? = null
     var highlightIdPassed: String? = null
     var bookIdPassed: String? = null
 
@@ -52,8 +52,8 @@ class FakeHighlightsRepository : HighlightsRepository {
             }
         }
 
-    override suspend fun deleteHighlightFromDb(highlight: Highlight): Result<Unit> {
-        deletedHighlight = highlight
+    override suspend fun deleteHighlightFromDb(highlightId: String): Result<Unit> {
+        deletedHighlightId = highlightId
         return if (shouldDeleteHighlightFromDbThrowException) {
             Result.failure(RuntimeException("Delete highlight failed"))
         } else {

--- a/core-data/src/test/java/com/sriniketh/core_data/usecases/DeleteHighlightUseCaseTest.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/usecases/DeleteHighlightUseCaseTest.kt
@@ -1,7 +1,6 @@
 package com.sriniketh.core_data.usecases
 
 import com.sriniketh.core_data.fakes.FakeHighlightsRepository
-import com.sriniketh.core_models.book.Highlight
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -21,42 +20,31 @@ class DeleteHighlightUseCaseTest {
 
     @Test
     fun `when repository deletion succeeds then returns success result`() = runTest {
-        val highlight = createTestHighlight()
         highlightsRepository.shouldDeleteHighlightFromDbThrowException = false
-        val result = deleteHighlightUseCase(highlight)
+        val result = deleteHighlightUseCase("test-highlight-id")
         assertTrue(result.isSuccess)
     }
 
     @Test
-    fun `when repository deletion succeeds then highlight is passed to repository`() = runTest {
-        val highlight = createTestHighlight()
+    fun `when repository deletion succeeds then highlight id is passed to repository`() = runTest {
         highlightsRepository.shouldDeleteHighlightFromDbThrowException = false
-        deleteHighlightUseCase(highlight)
-        assertEquals(highlight, highlightsRepository.deletedHighlight)
+        deleteHighlightUseCase("test-highlight-id")
+        assertEquals("test-highlight-id", highlightsRepository.deletedHighlightId)
     }
 
     @Test
     fun `when repository deletion fails then returns failure result`() = runTest {
-        val highlight = createTestHighlight()
         highlightsRepository.shouldDeleteHighlightFromDbThrowException = true
-        val result = deleteHighlightUseCase(highlight)
+        val result = deleteHighlightUseCase("test-highlight-id")
         assertTrue(result.isFailure)
     }
 
     @Test
     fun `when repository deletion fails then returns failure result with correct exception`() = runTest {
-        val highlight = createTestHighlight()
         highlightsRepository.shouldDeleteHighlightFromDbThrowException = true
-        val result = deleteHighlightUseCase(highlight)
+        val result = deleteHighlightUseCase("test-highlight-id")
         val exception = result.exceptionOrNull()
         assertTrue(exception is RuntimeException)
         assertEquals("Delete highlight failed", exception?.message)
     }
-
-    private fun createTestHighlight() = Highlight(
-        id = "test-highlight-id",
-        bookId = "test-book-id",
-        text = "Test highlight text",
-        savedOnTimestamp = "2023-01-01 12:00 PM"
-    )
 }

--- a/core-db/src/main/java/com/sriniketh/core_db/dao/HighlightDao.kt
+++ b/core-db/src/main/java/com/sriniketh/core_db/dao/HighlightDao.kt
@@ -1,7 +1,6 @@
 package com.sriniketh.core_db.dao
 
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -20,6 +19,6 @@ interface HighlightDao {
     @Query("SELECT * FROM highlightEntity WHERE bookId = :bookId")
     fun getAllHighlightsForBook(bookId: String): Flow<List<HighlightEntity>>
 
-    @Delete
-    suspend fun deleteHighlight(highlight: HighlightEntity)
+    @Query("DELETE FROM highlightEntity WHERE id = :id")
+    suspend fun deleteHighlightById(id: String)
 }

--- a/core-design/src/main/kotlin/com/sriniketh/core_design/ui/components/Placeholder.kt
+++ b/core-design/src/main/kotlin/com/sriniketh/core_design/ui/components/Placeholder.kt
@@ -2,15 +2,15 @@ package com.sriniketh.core_design.ui.components
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.painter.BrushPainter
 
 @Composable
-fun gradientPlaceholder() = BrushPainter(
-    Brush.linearGradient(
-        listOf(
-            MaterialTheme.colorScheme.surface,
-            MaterialTheme.colorScheme.surfaceVariant
-        )
-    )
-)
+fun gradientPlaceholder(): BrushPainter {
+    val surface = MaterialTheme.colorScheme.surface
+    val surfaceVariant = MaterialTheme.colorScheme.surfaceVariant
+    return remember(surface, surfaceVariant) {
+        BrushPainter(Brush.linearGradient(listOf(surface, surfaceVariant)))
+    }
+}

--- a/core-design/src/main/kotlin/com/sriniketh/core_design/ui/components/ProseTopAppBar.kt
+++ b/core-design/src/main/kotlin/com/sriniketh/core_design/ui/components/ProseTopAppBar.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sriniketh.core_design.ui.theme.AppTheme
@@ -21,16 +22,18 @@ fun ProseTopAppBar(
     actions: @Composable RowScope.() -> Unit = {},
     scrollBehavior: TopAppBarScrollBehavior? = null,
 ) {
+    val containerColor = MaterialTheme.colorScheme.background
+    val colors = TopAppBarDefaults.topAppBarColors(
+        containerColor = containerColor,
+        scrolledContainerColor = containerColor
+    ).let { remember(containerColor) { it } }
     LargeTopAppBar(
         title = title,
         modifier = modifier,
         navigationIcon = navigationIcon,
         actions = actions,
         scrollBehavior = scrollBehavior,
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.background,
-            scrolledContainerColor = MaterialTheme.colorScheme.background
-        )
+        colors = colors
     )
 }
 

--- a/core-design/src/main/kotlin/com/sriniketh/core_design/ui/theme/Theme.kt
+++ b/core-design/src/main/kotlin/com/sriniketh/core_design/ui/theme/Theme.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 
 private val LightColors = lightColorScheme(
@@ -82,11 +83,13 @@ fun AppTheme(
 ) {
     val context = LocalContext.current
     val isDynamicThemeAvailable = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-    val colors = when {
-        isDynamicThemeAvailable && useDarkTheme -> dynamicDarkColorScheme(context)
-        isDynamicThemeAvailable && !useDarkTheme -> dynamicLightColorScheme(context)
-        useDarkTheme -> DarkColors
-        else -> LightColors
+    val colors = remember(context, useDarkTheme, isDynamicThemeAvailable) {
+        when {
+            isDynamicThemeAvailable && useDarkTheme -> dynamicDarkColorScheme(context)
+            isDynamicThemeAvailable && !useDarkTheme -> dynamicLightColorScheme(context)
+            useDarkTheme -> DarkColors
+            else -> LightColors
+        }
     }
 
     MaterialTheme(

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CropImageScreen.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CropImageScreen.kt
@@ -72,7 +72,7 @@ internal fun CropImageScreen(
         val rotatedBitmap = rotatedBitmapState.value
         if (rotatedBitmap != null) {
             Cropify(
-                modifier = modifier
+                modifier = Modifier
                     .padding(contentPadding)
                     .fillMaxSize(),
                 bitmap = rotatedBitmap.asImageBitmap(),
@@ -87,7 +87,7 @@ internal fun CropImageScreen(
             )
         } else {
             Cropify(
-                modifier = modifier
+                modifier = Modifier
                     .padding(contentPadding)
                     .fillMaxSize(),
                 uri = imageUri,

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CropImageScreen.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CropImageScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asAndroidBitmap
@@ -24,13 +25,17 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import io.moyuru.cropify.Cropify
 import io.moyuru.cropify.rememberCropifyState
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun CropImageScreen(
     modifier: Modifier = Modifier,
     imageUri: Uri,
-    onImageCropped: () -> Unit
+    onImageCropped: () -> Unit,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
     val context = LocalContext.current
     val cropifyState = rememberCropifyState()
@@ -59,7 +64,12 @@ internal fun CropImageScreen(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { contentPadding ->
 
-        val rotatedBitmap = ImageRotater.getRotatedBitmap(context, imageUri)
+        val rotatedBitmapState = produceState<Bitmap?>(initialValue = null, key1 = imageUri) {
+            value = withContext(ioDispatcher) {
+                ImageRotater.getRotatedBitmap(context, imageUri)
+            }
+        }
+        val rotatedBitmap = rotatedBitmapState.value
         if (rotatedBitmap != null) {
             Cropify(
                 modifier = modifier

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreen.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreen.kt
@@ -203,19 +203,19 @@ internal fun EditAndSaveHighlight(
     ) { contentPadding ->
         if (uiState.isLoading) {
             LinearProgressIndicator(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .testTag("AddHighlightLoadingIndicator")
             )
         }
 
         Column(
-            modifier = modifier
+            modifier = Modifier
                 .padding(contentPadding)
                 .fillMaxSize()
         ) {
             BasicTextField(
-                modifier = modifier
+                modifier = Modifier
                     .weight(0.8f)
                     .fillMaxWidth()
                     .padding(18.dp)

--- a/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/fakes/FakeHighlightsRepository.kt
+++ b/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/fakes/FakeHighlightsRepository.kt
@@ -30,7 +30,7 @@ class FakeHighlightsRepository : HighlightsRepository {
         }
     }
 
-    override suspend fun deleteHighlightFromDb(highlight: Highlight): Result<Unit> {
+    override suspend fun deleteHighlightFromDb(highlightId: String): Result<Unit> {
         return if (shouldDeleteHighlightFromDbThrowException) {
             Result.failure(RuntimeException("Delete highlight failed"))
         } else {

--- a/feature-bookshelf/build.gradle.kts
+++ b/feature-bookshelf/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
 	implementation(project(":core-platform"))
 
 	implementation(libs.android.core.ktx)
+	implementation(libs.kotlinx.collections.immutable)
 	implementation(libs.coil)
 
 	val composeBom = platform(libs.compose.bom)

--- a/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
+++ b/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -92,7 +94,7 @@ class BookshelfScreenTest {
 
     @Test
     fun whenBooksListIsEmptyAndNotLoadingThenEmptyMessageIsDisplayed() {
-        val uiState = BookshelfUIState(isLoading = false, books = emptyList())
+        val uiState = BookshelfUIState(isLoading = false, books = persistentListOf())
 
         composeTestRule.setContent {
             AppTheme {
@@ -109,7 +111,7 @@ class BookshelfScreenTest {
 
     @Test
     fun whenBooksListIsNotEmptyThenEmptyMessageIsNotDisplayed() {
-        val books = listOf(createTestBookUIState())
+        val books = persistentListOf(createTestBookUIState())
         val uiState = BookshelfUIState(books = books)
 
         composeTestRule.setContent {
@@ -127,7 +129,7 @@ class BookshelfScreenTest {
 
     @Test
     fun whenBooksArePresentThenBookTitleIsDisplayed() {
-        val books = listOf(createTestBookUIState(title = "Test Book Title"))
+        val books = persistentListOf(createTestBookUIState(title = "Test Book Title"))
         val uiState = BookshelfUIState(books = books)
 
         composeTestRule.setContent {
@@ -145,7 +147,7 @@ class BookshelfScreenTest {
 
     @Test
     fun whenBooksArePresentThenBookAuthorsAreDisplayed() {
-        val books = listOf(createTestBookUIState(authors = listOf("Author One", "Author Two")))
+        val books = persistentListOf(createTestBookUIState(authors = persistentListOf("Author One", "Author Two")))
         val uiState = BookshelfUIState(books = books)
 
         composeTestRule.setContent {
@@ -164,7 +166,7 @@ class BookshelfScreenTest {
     @Test
     fun whenBookItemIsClickedThenGoToHighlightIsCalled() {
         val bookId = "test-book-id"
-        val books = listOf(createTestBookUIState(id = bookId, title = "Test Book"))
+        val books = persistentListOf(createTestBookUIState(id = bookId, title = "Test Book"))
         val uiState = BookshelfUIState(books = books)
         var calledBookId: String? = null
 
@@ -184,7 +186,7 @@ class BookshelfScreenTest {
 
     @Test
     fun whenNoBooksArePresentThenNoBookItemsAreDisplayed() {
-        val uiState = BookshelfUIState(books = emptyList())
+        val uiState = BookshelfUIState(books = persistentListOf())
 
         composeTestRule.setContent {
             AppTheme {
@@ -202,13 +204,12 @@ class BookshelfScreenTest {
     private fun createTestBookUIState(
         id: String = "test-id",
         title: String = "Test Title",
-        authors: List<String> = listOf("Test Author"),
+        authors: ImmutableList<String> = persistentListOf("Test Author"),
         thumbnailLink: String? = null
     ) = BookUIState(
         id = id,
         title = title,
         authors = authors,
-        thumbnailLink = thumbnailLink,
-        viewBook = {}
+        thumbnailLink = thumbnailLink
     )
 }

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
@@ -119,7 +119,7 @@ internal fun Bookshelf(
                 onClick = goToSearch,
                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                 contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                modifier = modifier.sharedBoundsTransition(key = AnimationConstants.BOOKSHELF_TO_SEARCH_BOUNDS_TRANSITION_KEY)
+                modifier = Modifier.sharedBoundsTransition(key = AnimationConstants.BOOKSHELF_TO_SEARCH_BOUNDS_TRANSITION_KEY)
             ) {
                 Icon(
                     painter = painterResource(com.sriniketh.core_design.R.drawable.ic_search),
@@ -131,7 +131,7 @@ internal fun Bookshelf(
     ) { contentPadding ->
         if (uiState.isLoading) {
             LinearProgressIndicator(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .testTag("BookshelfLoadingIndicator")
             )
@@ -139,7 +139,7 @@ internal fun Bookshelf(
 
         if (uiState.books.isEmpty() && !uiState.isLoading) {
             Box(
-                modifier = modifier.fillMaxSize()
+                modifier = Modifier.fillMaxSize()
             ) {
                 Text(
                     modifier = Modifier.align(Alignment.Center),
@@ -149,26 +149,26 @@ internal fun Bookshelf(
             }
         } else if (uiState.books.isNotEmpty()) {
             LazyColumn(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxSize()
                     .padding(contentPadding)
             ) {
                 itemsIndexed(uiState.books, key = { _, book -> book.id }) { _, bookUIState ->
                     Card(
-                        modifier = modifier
+                        modifier = Modifier
                             .fillMaxWidth()
                             .padding(12.dp)
                             .clickable { goToHighlight(bookUIState.id) },
                         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
                     ) {
                         Row(
-                            modifier = modifier
+                            modifier = Modifier
                                 .padding(12.dp)
                                 .align(Alignment.Start)
                         ) {
                             val uri = bookUIState.thumbnailLink?.buildHttpsUri()
                             AsyncImage(
-                                modifier = modifier
+                                modifier = Modifier
                                     .padding(6.dp)
                                     .height(100.dp)
                                     .width(80.dp)
@@ -180,17 +180,17 @@ internal fun Bookshelf(
                                 error = gradientPlaceholder()
                             )
                             Column(
-                                modifier = modifier
+                                modifier = Modifier
                                     .padding(horizontal = 6.dp)
                                     .align(Alignment.Top)
                             ) {
                                 Text(
-                                    modifier = modifier.padding(6.dp),
+                                    modifier = Modifier.padding(6.dp),
                                     text = bookUIState.title,
                                     style = MaterialTheme.typography.titleLarge
                                 )
                                 Text(
-                                    modifier = modifier.padding(6.dp),
+                                    modifier = Modifier.padding(6.dp),
                                     text = bookUIState.authors.joinToString(", "),
                                     style = MaterialTheme.typography.bodyLarge
                                 )

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
@@ -98,7 +98,7 @@ internal fun Bookshelf(
     goToSearch: () -> Unit,
     goToHighlight: (String) -> Unit
 ) {
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val scrollBehavior = run { TopAppBarDefaults.exitUntilCollapsedScrollBehavior() }.let { remember { it } }
     Scaffold(
         modifier = modifier
             .nestedScroll(scrollBehavior.nestedScrollConnection)

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
@@ -52,6 +52,7 @@ import com.sriniketh.core_design.ui.components.gradientPlaceholder
 import com.sriniketh.core_design.ui.sharedBoundsTransition
 import com.sriniketh.core_design.ui.theme.AppTheme
 import com.sriniketh.core_platform.buildHttpsUri
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 
 @Composable
@@ -209,49 +210,42 @@ internal fun BookshelfScreenSuccessPreview() {
     AppTheme {
         Bookshelf(
             uiState = BookshelfUIState(
-                books = listOf(
+                books = persistentListOf(
                     BookUIState(
                         id = "someId",
                         title = "Some title 1",
-                        authors = listOf("Author 1", "Author 2", "Author 3"),
-                        thumbnailLink = "https://picsum.photos/200/300",
-                        viewBook = {}
+                        authors = persistentListOf("Author 1", "Author 2", "Author 3"),
+                        thumbnailLink = "https://picsum.photos/200/300"
                     ), BookUIState(
                         id = "someId2",
                         title = "Some title 2",
-                        authors = listOf("Author 1"),
-                        thumbnailLink = "https://picsum.photos/200/300",
-                        viewBook = {}
+                        authors = persistentListOf("Author 1"),
+                        thumbnailLink = "https://picsum.photos/200/300"
                     ), BookUIState(
                         id = "someId3",
                         title = "Some title 3",
-                        authors = listOf("Author 1", "Author 2"),
-                        thumbnailLink = "https://picsum.photos/200/300",
-                        viewBook = {}
+                        authors = persistentListOf("Author 1", "Author 2"),
+                        thumbnailLink = "https://picsum.photos/200/300"
                     ), BookUIState(
                         id = "someId4",
                         title = "Some title 4",
-                        authors = listOf("Author 1", "Author 2"),
-                        thumbnailLink = "https://picsum.photos/200/300",
-                        viewBook = {}
+                        authors = persistentListOf("Author 1", "Author 2"),
+                        thumbnailLink = "https://picsum.photos/200/300"
                     ), BookUIState(
                         id = "someId5",
                         title = "Some title 5",
-                        authors = listOf("Author 1", "Author 2"),
-                        thumbnailLink = "https://picsum.photos/200/300",
-                        viewBook = {}
+                        authors = persistentListOf("Author 1", "Author 2"),
+                        thumbnailLink = "https://picsum.photos/200/300"
                     ), BookUIState(
                         id = "someId6",
                         title = "Some title 6",
-                        authors = listOf("Author 1", "Author 2"),
-                        thumbnailLink = "https://picsum.photos/200/300",
-                        viewBook = {}
+                        authors = persistentListOf("Author 1", "Author 2"),
+                        thumbnailLink = "https://picsum.photos/200/300"
                     ), BookUIState(
                         id = "someId7",
                         title = "Some title 7",
-                        authors = listOf("Author 1", "Author 2"),
-                        thumbnailLink = "https://picsum.photos/200/300",
-                        viewBook = {}
+                        authors = persistentListOf("Author 1", "Author 2"),
+                        thumbnailLink = "https://picsum.photos/200/300"
                     ))),
             goToSearch = {}, goToHighlight = {})
     }
@@ -272,7 +266,7 @@ internal fun BookshelfScreenLoadingPreview() {
 internal fun BookshelfScreenSuccessNoBooksPreview() {
     AppTheme {
         Bookshelf(
-            uiState = BookshelfUIState(books = emptyList()),
+            uiState = BookshelfUIState(books = persistentListOf()),
             goToSearch = {}, goToHighlight = {})
     }
 }

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfViewModel.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfViewModel.kt
@@ -7,6 +7,9 @@ import androidx.lifecycle.viewModelScope
 import com.sriniketh.core_data.usecases.GetAllSavedBooksUseCase
 import com.sriniketh.core_models.book.Book
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,8 +35,6 @@ class BookshelfViewModel @Inject constructor(
     private val _effects = Channel<BookshelfEffect>(Channel.BUFFERED)
     internal val effects: Flow<BookshelfEffect> = _effects.receiveAsFlow()
 
-    var viewHighlightsForBook: (String) -> Unit = {}
-
     init {
         viewModelScope.launch {
             savedStateHandle.getStateFlow(BOOKSHELF_SHOW_ADDED_MESSAGE, false)
@@ -54,7 +55,7 @@ class BookshelfViewModel @Inject constructor(
                     _bookshelfUIState.update { state ->
                         state.copy(
                             isLoading = false,
-                            books = books.map { it.asBookshelfUIState() }
+                            books = books.map { it.asBookshelfUIState() }.toImmutableList()
                         )
                     }
                 } else if (result.isFailure) {
@@ -70,25 +71,21 @@ class BookshelfViewModel @Inject constructor(
     private fun Book.asBookshelfUIState(): BookUIState = BookUIState(
         id = id,
         title = info.title,
-        authors = info.authors,
-        thumbnailLink = info.thumbnailLink,
-        viewBook = {
-            viewHighlightsForBook(id)
-        }
+        authors = info.authors.toImmutableList(),
+        thumbnailLink = info.thumbnailLink
     )
 }
 
 internal data class BookshelfUIState(
     val isLoading: Boolean = false,
-    val books: List<BookUIState> = emptyList()
+    val books: ImmutableList<BookUIState> = persistentListOf()
 )
 
 internal data class BookUIState(
     val id: String,
     val title: String,
-    val authors: List<String>,
-    val thumbnailLink: String?,
-    var viewBook: (String) -> Unit
+    val authors: ImmutableList<String>,
+    val thumbnailLink: String?
 )
 
 internal sealed interface BookshelfEffect {

--- a/feature-bookshelf/src/test/java/com/sriniketh/feature_bookshelf/BookshelfViewModelTest.kt
+++ b/feature-bookshelf/src/test/java/com/sriniketh/feature_bookshelf/BookshelfViewModelTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.collections.immutable.persistentListOf
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -81,7 +82,7 @@ class BookshelfViewModelTest {
             val bookUiState = loadedState.books[0]
             assertEquals("test-id", bookUiState.id)
             assertEquals("Test Title", bookUiState.title)
-            assertEquals(listOf("Test Author"), bookUiState.authors)
+            assertEquals(persistentListOf("Test Author"), bookUiState.authors)
             assertEquals("test-thumbnail", bookUiState.thumbnailLink)
         }
     }
@@ -121,24 +122,6 @@ class BookshelfViewModelTest {
                 expectNoEvents()
             }
         }
-
-    @Test
-    fun `when view highlights for book is set then book view action uses it`() = runTest {
-        val viewModel = BookshelfViewModel(getAllSavedBooksUseCase, SavedStateHandle())
-        var calledBookId: String? = null
-        viewModel.viewHighlightsForBook = { bookId -> calledBookId = bookId }
-
-        viewModel.bookshelfUIState.test {
-            skipItems(2)
-
-            val loadedState = awaitItem()
-            val bookUiState = loadedState.books[0]
-
-            bookUiState.viewBook(bookUiState.id)
-
-            assertEquals("test-id", calledBookId)
-        }
-    }
 
     @Test
     fun `when book added flag is set then added message is emitted and cleared`() = runTest {

--- a/feature-searchbooks/build.gradle.kts
+++ b/feature-searchbooks/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
 	androidTestImplementation(libs.compose.junit)
 	debugImplementation(libs.compose.test.manifest)
 
+	implementation(libs.kotlinx.collections.immutable)
+
 	implementation(libs.hilt.android)
 	ksp(libs.hilt.compiler)
 

--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
@@ -11,8 +11,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme
-import com.sriniketh.core_models.book.Book
-import com.sriniketh.core_models.book.BookInfo
+import kotlinx.collections.immutable.toImmutableList
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -273,7 +272,6 @@ class BookInfoScreenTest {
     }
 
     private fun createTestBook(
-        id: String = "test-id",
         title: String = "Test Title",
         authors: List<String> = listOf("Test Author"),
         publisher: String? = "Test Publisher",
@@ -282,19 +280,15 @@ class BookInfoScreenTest {
         averageRating: Double? = 4.0,
         ratingsCount: Int? = 100,
         publishedDate: String? = "2023"
-    ) = Book(
-        id = id,
-        info = BookInfo(
-            title = title,
-            subtitle = "Test Subtitle",
-            authors = authors,
-            thumbnailLink = null,
-            publisher = publisher,
-            publishedDate = publishedDate,
-            description = description,
-            pageCount = pageCount,
-            averageRating = averageRating,
-            ratingsCount = ratingsCount
-        )
+    ) = BookInfoUiData(
+        title = title,
+        authors = authors.toImmutableList(),
+        thumbnailLink = null,
+        publisher = publisher,
+        publishedDate = publishedDate,
+        description = description,
+        pageCount = pageCount,
+        averageRating = averageRating,
+        ratingsCount = ratingsCount
     )
 }

--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
@@ -12,6 +12,9 @@ import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -81,7 +84,7 @@ class SearchBookScreenTest {
 
     @Test
     fun whenBooksArePresentThenBookTitleIsDisplayed() {
-        val books = listOf(createTestBookUiState(title = "Test Book Title"))
+        val books = persistentListOf(createTestBookUiState(title = "Test Book Title"))
         val uiState = BookSearchUiState(bookUiStates = books)
 
         composeTestRule.setContent {
@@ -101,7 +104,7 @@ class SearchBookScreenTest {
 
     @Test
     fun whenBooksArePresentThenBookAuthorsAreDisplayed() {
-        val books = listOf(createTestBookUiState(authors = listOf("Author One", "Author Two")))
+        val books = persistentListOf(createTestBookUiState(authors = persistentListOf("Author One", "Author Two")))
         val uiState = BookSearchUiState(bookUiStates = books)
 
         composeTestRule.setContent {
@@ -121,7 +124,7 @@ class SearchBookScreenTest {
 
     @Test
     fun whenBooksArePresentThenBookSubtitleIsDisplayed() {
-        val books = listOf(createTestBookUiState(subtitle = "Test Subtitle"))
+        val books = persistentListOf(createTestBookUiState(subtitle = "Test Subtitle"))
         val uiState = BookSearchUiState(bookUiStates = books)
 
         composeTestRule.setContent {
@@ -142,7 +145,7 @@ class SearchBookScreenTest {
     @Test
     fun whenBookItemIsClickedThenNavigateToBookInfoIsCalled() {
         val bookId = "test-book-id"
-        val books = listOf(createTestBookUiState(id = bookId, title = "Test Book"))
+        val books = persistentListOf(createTestBookUiState(id = bookId, title = "Test Book"))
         val uiState = BookSearchUiState(bookUiStates = books)
         var navigatedBookId: String? = null
 
@@ -228,7 +231,7 @@ class SearchBookScreenTest {
 
     @Test
     fun whenNoBooksArePresentThenNoBookItemsAreDisplayed() {
-        val uiState = BookSearchUiState(bookUiStates = emptyList())
+        val uiState = BookSearchUiState(bookUiStates = persistentListOf())
 
         composeTestRule.setContent {
             AppTheme {
@@ -248,10 +251,10 @@ class SearchBookScreenTest {
     fun whenNewResultsArriveThenTheListIsShownFromTheTop() {
         val sharedBooks = (0 until 20).map { index ->
             createTestBookUiState(id = "shared-$index", title = "Shared Book $index")
-        }
+        }.toPersistentList()
         val newTopBooks = (0 until 5).map { index ->
             createTestBookUiState(id = "new-$index", title = "New Top Book $index")
-        }
+        }.toPersistentList()
         val uiState = mutableStateOf(BookSearchUiState(bookUiStates = sharedBooks))
 
         composeTestRule.setContent {
@@ -269,7 +272,7 @@ class SearchBookScreenTest {
         composeTestRule.onNodeWithTag("SearchResultsList").performScrollToIndex(19)
         composeTestRule.waitForIdle()
 
-        uiState.value = BookSearchUiState(bookUiStates = newTopBooks + sharedBooks)
+        uiState.value = BookSearchUiState(bookUiStates = (newTopBooks + sharedBooks).toPersistentList())
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("New Top Book 0").assertIsDisplayed()
@@ -279,7 +282,7 @@ class SearchBookScreenTest {
         id: String = "test-id",
         title: String = "Test Title",
         subtitle: String? = "Test Subtitle",
-        authors: List<String> = listOf("Test Author"),
+        authors: ImmutableList<String> = persistentListOf("Test Author"),
         thumbnailLink: String? = null
     ) = BookUiState(
         id = id,

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -105,7 +105,7 @@ internal fun BookInfo(
     modifier: Modifier = Modifier,
     goBack: () -> Unit
 ) {
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val scrollBehavior = run { TopAppBarDefaults.exitUntilCollapsedScrollBehavior() }.let { remember { it } }
     Scaffold(
         modifier = modifier
             .fillMaxSize()
@@ -142,8 +142,7 @@ private fun BookInfoLayout(
     uiState: BookInfoUiState,
     contentPadding: PaddingValues
 ) {
-    uiState.book?.let { book ->
-        val bookInfo = book
+    uiState.book?.let { bookInfo ->
         Column(
             modifier = Modifier
                 .verticalScroll(rememberScrollState())

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -126,7 +126,7 @@ internal fun BookInfo(
     ) { contentPadding ->
         if (uiState.isLoading) {
             LinearProgressIndicator(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .padding(contentPadding)
                     .testTag("BookInfoLoadingIndicator")
@@ -146,19 +146,19 @@ private fun BookInfoLayout(
     uiState.book?.let { book ->
         val bookInfo = book
         Column(
-            modifier = modifier
+            modifier = Modifier
                 .verticalScroll(rememberScrollState())
                 .fillMaxSize()
                 .padding(contentPadding)
         ) {
             Row(
-                modifier = modifier
+                modifier = Modifier
                     .padding(12.dp)
                     .align(Alignment.Start)
             ) {
                 val uri = bookInfo.thumbnailLink?.buildHttpsUri()
                 AsyncImage(
-                    modifier = modifier
+                    modifier = Modifier
                         .padding(6.dp)
                         .height(160.dp)
                         .width(120.dp)
@@ -170,20 +170,20 @@ private fun BookInfoLayout(
                     error = gradientPlaceholder()
                 )
                 Column(
-                    modifier = modifier
+                    modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 6.dp),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
                     Column {
                         Text(
-                            modifier = modifier.padding(6.dp),
+                            modifier = Modifier.padding(6.dp),
                             text = bookInfo.authors.joinToString(", "),
                             style = MaterialTheme.typography.titleLarge
                         )
                         bookInfo.publisher?.let { publisher ->
                             Text(
-                                modifier = modifier.padding(6.dp),
+                                modifier = Modifier.padding(6.dp),
                                 text = publisher,
                                 style = MaterialTheme.typography.bodyLarge
                             )
@@ -209,17 +209,17 @@ private fun BookInfoLayout(
                 }
             }
             Card(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .padding(12.dp),
                 colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
             ) {
-                Column(modifier = modifier.padding(12.dp)) {
+                Column(modifier = Modifier.padding(12.dp)) {
                     val averageRating = bookInfo.averageRating
                     val ratingsCount = bookInfo.ratingsCount
                     if (averageRating != null && ratingsCount != null) {
                         Text(
-                            modifier = modifier.padding(6.dp),
+                            modifier = Modifier.padding(6.dp),
                             text = stringResource(
                                 id = R.string.book_info_ratings_template,
                                 averageRating,
@@ -230,7 +230,7 @@ private fun BookInfoLayout(
                     }
                     bookInfo.pageCount?.let {
                         Text(
-                            modifier = modifier.padding(6.dp),
+                            modifier = Modifier.padding(6.dp),
                             text = stringResource(
                                 id = R.string.book_info_pagecount_template,
                                 it
@@ -240,7 +240,7 @@ private fun BookInfoLayout(
                     }
                     bookInfo.publisher?.let {
                         Text(
-                            modifier = modifier.padding(6.dp),
+                            modifier = Modifier.padding(6.dp),
                             text = stringResource(
                                 id = R.string.book_info_publisher_template,
                                 it
@@ -250,7 +250,7 @@ private fun BookInfoLayout(
                     }
                     bookInfo.publishedDate?.let {
                         Text(
-                            modifier = modifier.padding(6.dp),
+                            modifier = Modifier.padding(6.dp),
                             text = stringResource(
                                 id = R.string.book_info_publish_date_template,
                                 it

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -133,14 +133,13 @@ internal fun BookInfo(
             )
         }
 
-        BookInfoLayout(uiState, modifier, contentPadding)
+        BookInfoLayout(uiState, contentPadding)
     }
 }
 
 @Composable
 private fun BookInfoLayout(
     uiState: BookInfoUiState,
-    modifier: Modifier,
     contentPadding: PaddingValues
 ) {
     uiState.book?.let { book ->

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -193,16 +193,18 @@ private fun BookInfoLayout(
                 }
             }
             bookInfo.description?.let { description ->
+                val descriptionText = remember(description) {
+                    Html.fromHtml(description, Html.FROM_HTML_MODE_LEGACY).toString()
+                }
                 Card(
-                    modifier = modifier
+                    modifier = Modifier
                         .fillMaxWidth()
                         .padding(12.dp),
                     colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
                 ) {
                     Text(
-                        modifier = modifier.padding(12.dp),
-                        text = Html.fromHtml(description, Html.FROM_HTML_MODE_LEGACY)
-                            .toString(),
+                        modifier = Modifier.padding(12.dp),
+                        text = descriptionText,
                         style = MaterialTheme.typography.bodyLarge
                     )
                 }

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -55,9 +55,8 @@ import com.sriniketh.core_design.ui.components.NavigationBack
 import com.sriniketh.core_design.ui.components.ProseTopAppBar
 import com.sriniketh.core_design.ui.components.gradientPlaceholder
 import com.sriniketh.core_design.ui.theme.AppTheme
-import com.sriniketh.core_models.book.Book
-import com.sriniketh.core_models.book.BookInfo
 import com.sriniketh.core_platform.buildHttpsUri
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 
 @Composable
@@ -145,7 +144,7 @@ private fun BookInfoLayout(
     contentPadding: PaddingValues
 ) {
     uiState.book?.let { book ->
-        val bookInfo = book.info
+        val bookInfo = book
         Column(
             modifier = modifier
                 .verticalScroll(rememberScrollState())
@@ -295,7 +294,7 @@ private fun BookInfoScreenFloatingActionButton(buttonOnClick: () -> Unit) {
 private fun BookInfoScreenTitle(uiState: BookInfoUiState) {
     uiState.book?.let { book ->
         Text(
-            text = book.info.title,
+            text = book.title,
             style = MaterialTheme.typography.headlineMedium,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis
@@ -309,20 +308,16 @@ internal fun BookInfoScreenPreview() {
     AppTheme {
         BookInfo(
             uiState = BookInfoUiState(
-                book = Book(
-                    id = "someId",
-                    info = BookInfo(
-                        title = "some really really really long title",
-                        subtitle = "some subtitle",
-                        authors = listOf("author 1, author 2"),
-                        thumbnailLink = "https://picsum.photos/200/300",
-                        publisher = "some publisher",
-                        publishedDate = "23rd January 2021",
-                        description = "some description that's repeated again and again so that we have this long piece of text. some description that's repeated again and again so that we have this long piece of text.",
-                        pageCount = 215,
-                        averageRating = 4.3,
-                        ratingsCount = 1227
-                    )
+                book = BookInfoUiData(
+                    title = "some really really really long title",
+                    authors = persistentListOf("author 1, author 2"),
+                    thumbnailLink = "https://picsum.photos/200/300",
+                    publisher = "some publisher",
+                    publishedDate = "23rd January 2021",
+                    description = "some description that's repeated again and again so that we have this long piece of text. some description that's repeated again and again so that we have this long piece of text.",
+                    pageCount = 215,
+                    averageRating = 4.3,
+                    ratingsCount = 1227
                 ),
                 canAddToShelf = true,
                 addBookToShelf = {}

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt
@@ -3,11 +3,14 @@ package com.sriniketh.feature_searchbooks
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.sriniketh.core_data.usecases.FetchBookInfoUseCase
 import com.sriniketh.core_data.usecases.AddBookToShelfUseCase
+import com.sriniketh.core_data.usecases.FetchBookInfoUseCase
 import com.sriniketh.core_data.usecases.IsBookInDbUseCase
 import com.sriniketh.core_models.book.Book
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,7 +47,7 @@ class BookInfoViewModel @Inject constructor(
                 _uiState.update { state ->
                     state.copy(
                         isLoading = false,
-                        book = book,
+                        book = book.asUiData(),
                         canAddToShelf = !isInDb,
                         addBookToShelf = { addBookToShelf(book) }
                     )
@@ -80,13 +83,37 @@ class BookInfoViewModel @Inject constructor(
             }
         }
     }
+
+    private fun Book.asUiData(): BookInfoUiData = BookInfoUiData(
+        title = info.title,
+        authors = info.authors.toImmutableList(),
+        thumbnailLink = info.thumbnailLink,
+        publisher = info.publisher,
+        publishedDate = info.publishedDate,
+        description = info.description,
+        pageCount = info.pageCount,
+        averageRating = info.averageRating,
+        ratingsCount = info.ratingsCount
+    )
 }
 
 data class BookInfoUiState(
     val isLoading: Boolean = false,
-    val book: Book? = null,
+    val book: BookInfoUiData? = null,
     val canAddToShelf: Boolean = false,
     val addBookToShelf: () -> Unit = {}
+)
+
+data class BookInfoUiData(
+    val title: String,
+    val authors: ImmutableList<String> = persistentListOf(),
+    val thumbnailLink: String?,
+    val publisher: String?,
+    val publishedDate: String?,
+    val description: String?,
+    val pageCount: Int?,
+    val averageRating: Double?,
+    val ratingsCount: Int?
 )
 
 internal sealed interface BookInfoEffect {

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
@@ -49,6 +49,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 import coil.compose.AsyncImage
 import com.sriniketh.core_design.ui.AnimationConstants
@@ -251,12 +252,12 @@ internal fun SearchBookScreenPreview() {
         Surface {
             SearchBook(
                 uiState = BookSearchUiState(
-                    bookUiStates = listOf(
+                    bookUiStates = persistentListOf(
                         BookUiState(
                             id = "some book id",
                             title = "some book",
                             subtitle = "some subtitle",
-                            authors = listOf(""),
+                            authors = persistentListOf(""),
                             thumbnailLink = null
                         )
                     )

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
@@ -124,7 +124,7 @@ internal fun SearchBook(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { contentPadding ->
         SearchBar(
-            modifier = modifier
+            modifier = Modifier
                 .padding(contentPadding)
                 .focusRequester(focusRequester)
                 .fillMaxWidth(),
@@ -157,7 +157,7 @@ internal fun SearchBook(
                     trailingIcon = {
                         if (expanded) {
                             Icon(
-                                modifier = modifier.clickable {
+                                modifier = Modifier.clickable {
                                     if (text.isNotEmpty()) {
                                         text = ""
                                         resetSearch()
@@ -179,21 +179,21 @@ internal fun SearchBook(
         ) {
             if (uiState.isLoading) {
                 LinearProgressIndicator(
-                    modifier = modifier
+                    modifier = Modifier
                         .fillMaxWidth()
                         .testTag("SearchBookLoadingIndicator")
                 )
             }
             LazyColumn(
                 state = listState,
-                modifier = modifier
+                modifier = Modifier
                     .padding(contentPadding)
                     .fillMaxSize()
                     .testTag("SearchResultsList")
             ) {
                 itemsIndexed(uiState.bookUiStates, key = { _, item -> item.id }) { _, item ->
                     Row(
-                        modifier = modifier
+                        modifier = Modifier
                             .padding(12.dp)
                             .align(Alignment.Start)
                             .fillMaxWidth()
@@ -201,7 +201,7 @@ internal fun SearchBook(
                     ) {
                         val uri = item.thumbnailLink?.buildHttpsUri()
                         AsyncImage(
-                            modifier = modifier
+                            modifier = Modifier
                                 .padding(6.dp)
                                 .height(80.dp)
                                 .width(60.dp)
@@ -213,28 +213,28 @@ internal fun SearchBook(
                             error = gradientPlaceholder()
                         )
                         Column(
-                            modifier = modifier
+                            modifier = Modifier
                                 .padding(horizontal = 6.dp)
                                 .align(Alignment.Top)
                         ) {
                             Text(
-                                modifier = modifier.padding(6.dp),
+                                modifier = Modifier.padding(6.dp),
                                 text = item.title,
                                 style = MaterialTheme.typography.bodyLarge
                             )
                             Text(
-                                modifier = modifier.padding(6.dp),
+                                modifier = Modifier.padding(6.dp),
                                 text = item.authors.joinToString(", "),
                                 style = MaterialTheme.typography.bodyMedium
                             )
                             Text(
-                                modifier = modifier.padding(6.dp),
+                                modifier = Modifier.padding(6.dp),
                                 text = item.subtitle.orEmpty(),
                                 style = MaterialTheme.typography.bodySmall
                             )
                         }
                     }
-                    HorizontalDivider(modifier = modifier.fillMaxWidth())
+                    HorizontalDivider(modifier = Modifier.fillMaxWidth())
                 }
             }
         }

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookViewModel.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookViewModel.kt
@@ -23,6 +23,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.receiveAsFlow
 import javax.inject.Inject
 
@@ -75,7 +78,7 @@ class SearchBookViewModel @Inject constructor(
             emit(
                 BookSearchUiState(
                     isLoading = false,
-                    bookUiStates = result.getOrThrow().items.map { it.asBookUiState() }
+                    bookUiStates = result.getOrThrow().items.map { it.asBookUiState() }.toImmutableList()
                 )
             )
         } else {
@@ -88,7 +91,7 @@ class SearchBookViewModel @Inject constructor(
         id = id,
         title = info.title,
         subtitle = info.subtitle,
-        authors = info.authors,
+        authors = info.authors.toImmutableList(),
         thumbnailLink = info.thumbnailLink
     )
 
@@ -105,14 +108,14 @@ class SearchBookViewModel @Inject constructor(
 
 internal data class BookSearchUiState(
     val isLoading: Boolean = false,
-    val bookUiStates: List<BookUiState> = emptyList()
+    val bookUiStates: ImmutableList<BookUiState> = persistentListOf()
 )
 
 internal data class BookUiState(
     val id: String,
     val title: String,
     val subtitle: String?,
-    val authors: List<String>,
+    val authors: ImmutableList<String>,
     val thumbnailLink: String?
 )
 

--- a/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/BookInfoViewModelTest.kt
+++ b/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/BookInfoViewModelTest.kt
@@ -77,7 +77,7 @@ class BookInfoViewModelTest {
             val successState = awaitItem()
             assertFalse(successState.isLoading)
             assertNotNull(successState.book)
-            assertEquals("test-id", successState.book?.id)
+            assertEquals("Test Title", successState.book?.title)
             assertTrue(successState.canAddToShelf)
         }
     }

--- a/feature-viewhighlights/build.gradle.kts
+++ b/feature-viewhighlights/build.gradle.kts
@@ -61,6 +61,8 @@ dependencies {
 	androidTestImplementation(libs.compose.junit)
 	debugImplementation(libs.compose.test.manifest)
 
+	implementation(libs.kotlinx.collections.immutable)
+
 	implementation(libs.hilt.android)
 	ksp(libs.hilt.compiler)
 

--- a/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
+++ b/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme
+import kotlinx.collections.immutable.persistentListOf
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -22,7 +23,7 @@ class ViewHighlightsScreenTest {
 
     @Test
     fun whenHighlightsListIsEmptyThenEmptyMessageIsDisplayed() {
-        val uiState = ViewHighlightsUIState(highlights = emptyList())
+        val uiState = ViewHighlightsUIState(highlights = persistentListOf())
 
         composeTestRule.setContent {
             AppTheme {
@@ -39,7 +40,7 @@ class ViewHighlightsScreenTest {
 
     @Test
     fun whenHighlightsListIsNotEmptyThenEmptyMessageIsNotDisplayed() {
-        val highlights = listOf(createTestHighlightUIState())
+        val highlights = persistentListOf(createTestHighlightUIState())
         val uiState = ViewHighlightsUIState(highlights = highlights)
 
         composeTestRule.setContent {
@@ -58,7 +59,7 @@ class ViewHighlightsScreenTest {
     @Test
     fun whenHighlightsArePresentThenHighlightTextIsDisplayed() {
         val highlightText = "This is a test highlight"
-        val highlights = listOf(createTestHighlightUIState(text = highlightText))
+        val highlights = persistentListOf(createTestHighlightUIState(text = highlightText))
         val uiState = ViewHighlightsUIState(highlights = highlights)
 
         composeTestRule.setContent {
@@ -77,7 +78,7 @@ class ViewHighlightsScreenTest {
     @Test
     fun whenHighlightsArePresentThenSavedTimestampIsDisplayed() {
         val savedOn = "2023-12-25"
-        val highlights = listOf(createTestHighlightUIState(savedOn = savedOn))
+        val highlights = persistentListOf(createTestHighlightUIState(savedOn = savedOn))
         val uiState = ViewHighlightsUIState(highlights = highlights)
 
         composeTestRule.setContent {
@@ -95,7 +96,7 @@ class ViewHighlightsScreenTest {
 
     @Test
     fun whenHighlightsArePresentThenMoreOptionsButtonIsDisplayed() {
-        val highlights = listOf(createTestHighlightUIState())
+        val highlights = persistentListOf(createTestHighlightUIState())
         val uiState = ViewHighlightsUIState(highlights = highlights)
 
         composeTestRule.setContent {
@@ -166,7 +167,7 @@ class ViewHighlightsScreenTest {
 
     @Test
     fun whenMoreOptionsIsClickedThenDropdownMenuIsDisplayed() {
-        val highlights = listOf(createTestHighlightUIState())
+        val highlights = persistentListOf(createTestHighlightUIState())
         val uiState = ViewHighlightsUIState(highlights = highlights)
 
         composeTestRule.setContent {
@@ -188,7 +189,7 @@ class ViewHighlightsScreenTest {
     @Test
     fun whenEditMenuItemIsClickedThenOnEditHighlightEventIsTriggered() {
         val highlightId = "test-highlight-id"
-        val highlights = listOf(createTestHighlightUIState(id = highlightId))
+        val highlights = persistentListOf(createTestHighlightUIState(id = highlightId))
         val uiState = ViewHighlightsUIState(highlights = highlights)
         var actionTriggered: ViewHighlightsAction? = null
 
@@ -210,7 +211,7 @@ class ViewHighlightsScreenTest {
 
     @Test
     fun whenDeleteMenuItemIsClickedThenDeleteDialogIsDisplayed() {
-        val highlights = listOf(createTestHighlightUIState())
+        val highlights = persistentListOf(createTestHighlightUIState())
         val uiState = ViewHighlightsUIState(highlights = highlights)
 
         composeTestRule.setContent {
@@ -231,22 +232,16 @@ class ViewHighlightsScreenTest {
 
     @Test
     fun whenDeleteDialogConfirmIsClickedThenOnDeleteIsCalled() {
-        val highlights = listOf(createTestHighlightUIState())
-        val uiState = ViewHighlightsUIState(highlights = highlights)
-        var onDeleteCalled = false
+        val highlightId = "test-id"
+        val uiState = ViewHighlightsUIState(highlights = persistentListOf(createTestHighlightUIState(id = highlightId)))
+        var actionTriggered: ViewHighlightsAction? = null
 
         composeTestRule.setContent {
             AppTheme {
                 ViewHighlights(
-                    uiState = uiState.copy(
-                        highlights = listOf(
-                            createTestHighlightUIState(
-                                onDelete = { onDeleteCalled = true }
-                            )
-                        )
-                    ),
+                    uiState = uiState,
                     bookId = "test-book-id",
-                    onAction = {}
+                    onAction = { actionTriggered = it }
                 )
             }
         }
@@ -254,12 +249,13 @@ class ViewHighlightsScreenTest {
         composeTestRule.onNodeWithContentDescription("Options Menu").performClick()
         composeTestRule.onNodeWithText("Delete").performClick()
         composeTestRule.onNodeWithText("Delete").performClick()
-        assertTrue(onDeleteCalled)
+        assertTrue(actionTriggered is ViewHighlightsAction.OnDeleteHighlight)
+        assertEquals(highlightId, (actionTriggered as ViewHighlightsAction.OnDeleteHighlight).highlightId)
     }
 
     @Test
     fun whenDeleteDialogCancelIsClickedThenDialogIsDismissed() {
-        val highlights = listOf(createTestHighlightUIState())
+        val highlights = persistentListOf(createTestHighlightUIState())
         val uiState = ViewHighlightsUIState(highlights = highlights)
 
         composeTestRule.setContent {
@@ -281,12 +277,10 @@ class ViewHighlightsScreenTest {
     private fun createTestHighlightUIState(
         id: String = "test-id",
         text: String = "test text",
-        savedOn: String = "2023-01-01",
-        onDelete: () -> Unit = {}
+        savedOn: String = "2023-01-01"
     ) = HighlightUIState(
         id = id,
         text = text,
-        savedOn = savedOn,
-        onDelete = onDelete
+        savedOn = savedOn
     )
 }

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -208,12 +208,12 @@ internal fun ViewHighlights(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { contentPadding ->
         if (uiState.isLoading) {
-            LinearProgressIndicator(modifier = modifier.fillMaxWidth())
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
         }
 
         if (uiState.highlights.isEmpty()) {
             Box(
-                modifier = modifier.fillMaxSize()
+                modifier = Modifier.fillMaxSize()
             ) {
                 Text(
                     modifier = Modifier.align(Alignment.Center),
@@ -223,7 +223,7 @@ internal fun ViewHighlights(
             }
         } else {
             LazyColumn(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxSize()
                     .padding(contentPadding),
                 state = lazyListState
@@ -254,7 +254,7 @@ internal fun ViewHighlights(
                     }
 
                     Row(
-                        modifier = modifier
+                        modifier = Modifier
                             .fillMaxWidth()
                             .padding(12.dp)
                             .animateContentSize()
@@ -265,16 +265,16 @@ internal fun ViewHighlights(
                             },
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
-                        Column(modifier = modifier.weight(1f)) {
+                        Column(modifier = Modifier.weight(1f)) {
                             SelectionContainer {
                                 Text(
-                                    modifier = modifier.padding(6.dp),
+                                    modifier = Modifier.padding(6.dp),
                                     text = highlightText,
                                     style = MaterialTheme.typography.bodyLarge
                                 )
                             }
                             Text(
-                                modifier = modifier.padding(6.dp),
+                                modifier = Modifier.padding(6.dp),
                                 text = stringResource(
                                     id = R.string.highlight_item_saved_on_template,
                                     highlightUiState.savedOn
@@ -294,7 +294,7 @@ internal fun ViewHighlights(
                                 )
                             }
                             DropdownMenu(
-                                modifier = modifier.clickable { expandDropDownMenu = true },
+                                modifier = Modifier.clickable { expandDropDownMenu = true },
                                 expanded = expandDropDownMenu,
                                 onDismissRequest = { expandDropDownMenu = false }) {
                                 DropdownMenuItem(
@@ -338,7 +338,7 @@ internal fun ViewHighlights(
                             }
                         }
                     }
-                    HorizontalDivider(modifier = modifier.fillMaxWidth())
+                    HorizontalDivider(modifier = Modifier.fillMaxWidth())
                 }
             }
         }

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -164,7 +164,7 @@ internal fun ViewHighlights(
             lazyListState.firstVisibleItemIndex < 2
         }
     }
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val scrollBehavior = run { TopAppBarDefaults.exitUntilCollapsedScrollBehavior() }.let { remember { it } }
     Scaffold(
         modifier = modifier
             .fillMaxSize()

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -231,9 +231,12 @@ internal fun ViewHighlights(
                 items(uiState.highlights, key = { it.id }) { highlightUiState ->
                     var showDeleteDialog by remember { mutableStateOf(false) }
                     if (showDeleteDialog) {
-                        DeleteHighlightAlertDialog(highlightUiState) {
-                            showDeleteDialog = false
-                        }
+                        DeleteHighlightAlertDialog(
+                            onConfirm = {
+                                onAction(ViewHighlightsAction.OnDeleteHighlight(highlightUiState.id))
+                            },
+                            hideDeleteDialog = { showDeleteDialog = false }
+                        )
                     }
 
                     var expandDropDownMenu by remember { mutableStateOf(false) }
@@ -344,7 +347,7 @@ internal fun ViewHighlights(
 
 @Composable
 private fun DeleteHighlightAlertDialog(
-    highlightUiState: HighlightUIState,
+    onConfirm: () -> Unit,
     hideDeleteDialog: () -> Unit
 ) {
     val haptic = LocalHapticFeedback.current
@@ -364,7 +367,7 @@ private fun DeleteHighlightAlertDialog(
         confirmButton = {
             ElevatedButton(
                 onClick = {
-                    highlightUiState.onDelete()
+                    onConfirm()
                     hideDeleteDialog()
                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                 },

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModel.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModel.kt
@@ -37,8 +37,6 @@ class ViewHighlightsViewModel @Inject constructor(
     private val _effects = Channel<ViewHighlightsEffect>(Channel.BUFFERED)
     internal val effects: Flow<ViewHighlightsEffect> = _effects.receiveAsFlow()
 
-    private var loadedHighlights: List<Highlight> = emptyList()
-
     internal fun getHighlights(bookId: String) {
         viewModelScope.launch {
             _highlightsUIStateFlow.update { state ->
@@ -47,7 +45,6 @@ class ViewHighlightsViewModel @Inject constructor(
             getAllSavedHighlightsUseCase(bookId).collect { result ->
                 if (result.isSuccess) {
                     val highlights = result.getOrThrow().sortedBy { it.savedOnTimestamp }
-                    loadedHighlights = highlights
                     _highlightsUIStateFlow.update { state ->
                         state.copy(
                             isLoading = false,
@@ -86,12 +83,11 @@ class ViewHighlightsViewModel @Inject constructor(
     }
 
     private fun deleteHighlight(highlightId: String) {
-        val target = loadedHighlights.firstOrNull { it.id == highlightId } ?: return
         viewModelScope.launch {
             _highlightsUIStateFlow.update { state ->
                 state.copy(isLoading = true)
             }
-            val result = deleteHighlightUseCase.invoke(target)
+            val result = deleteHighlightUseCase.invoke(highlightId)
             if (result.isFailure) {
                 _highlightsUIStateFlow.update { state ->
                     state.copy(isLoading = false)

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModel.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModel.kt
@@ -9,6 +9,9 @@ import com.sriniketh.core_data.usecases.ExportHighlightsUseCase
 import com.sriniketh.core_data.usecases.GetAllSavedHighlightsUseCase
 import com.sriniketh.core_models.book.Highlight
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,6 +37,8 @@ class ViewHighlightsViewModel @Inject constructor(
     private val _effects = Channel<ViewHighlightsEffect>(Channel.BUFFERED)
     internal val effects: Flow<ViewHighlightsEffect> = _effects.receiveAsFlow()
 
+    private var loadedHighlights: List<Highlight> = emptyList()
+
     internal fun getHighlights(bookId: String) {
         viewModelScope.launch {
             _highlightsUIStateFlow.update { state ->
@@ -41,12 +46,12 @@ class ViewHighlightsViewModel @Inject constructor(
             }
             getAllSavedHighlightsUseCase(bookId).collect { result ->
                 if (result.isSuccess) {
-                    val highlights = result.getOrThrow()
+                    val highlights = result.getOrThrow().sortedBy { it.savedOnTimestamp }
+                    loadedHighlights = highlights
                     _highlightsUIStateFlow.update { state ->
                         state.copy(
                             isLoading = false,
-                            highlights = highlights.sortedBy { it.savedOnTimestamp }
-                                .map { it.asHighlightUIState() }
+                            highlights = highlights.map { it.asHighlightUIState() }.toImmutableList()
                         )
                     }
                 } else if (result.isFailure) {
@@ -72,7 +77,27 @@ class ViewHighlightsViewModel @Inject constructor(
                 exportHighlights(action.bookId)
             }
 
+            is ViewHighlightsAction.OnDeleteHighlight -> {
+                deleteHighlight(action.highlightId)
+            }
+
             else -> Unit
+        }
+    }
+
+    private fun deleteHighlight(highlightId: String) {
+        val target = loadedHighlights.firstOrNull { it.id == highlightId } ?: return
+        viewModelScope.launch {
+            _highlightsUIStateFlow.update { state ->
+                state.copy(isLoading = true)
+            }
+            val result = deleteHighlightUseCase.invoke(target)
+            if (result.isFailure) {
+                _highlightsUIStateFlow.update { state ->
+                    state.copy(isLoading = false)
+                }
+                _effects.trySend(ViewHighlightsEffect.ShowMessage(R.string.delete_error_message))
+            }
         }
     }
 
@@ -99,34 +124,19 @@ class ViewHighlightsViewModel @Inject constructor(
     private fun Highlight.asHighlightUIState(): HighlightUIState = HighlightUIState(
         id = id,
         text = text,
-        savedOn = savedOnTimestamp,
-        onDelete = {
-            viewModelScope.launch {
-                _highlightsUIStateFlow.update { state ->
-                    state.copy(isLoading = true)
-                }
-                val result = deleteHighlightUseCase.invoke(this@asHighlightUIState)
-                if (result.isFailure) {
-                    _highlightsUIStateFlow.update { state ->
-                        state.copy(isLoading = false)
-                    }
-                    _effects.trySend(ViewHighlightsEffect.ShowMessage(R.string.delete_error_message))
-                }
-            }
-        }
+        savedOn = savedOnTimestamp
     )
 }
 
 internal data class ViewHighlightsUIState(
     val isLoading: Boolean = false,
-    val highlights: List<HighlightUIState> = emptyList()
+    val highlights: ImmutableList<HighlightUIState> = persistentListOf()
 )
 
 internal data class HighlightUIState(
     val id: String,
     val text: String,
-    val savedOn: String,
-    val onDelete: () -> Unit
+    val savedOn: String
 )
 
 internal sealed interface ViewHighlightsAction {
@@ -135,6 +145,7 @@ internal sealed interface ViewHighlightsAction {
     data object OnCameraPermissionGranted : ViewHighlightsAction
     data class OnEditHighlight(val highlightId: String) : ViewHighlightsAction
     data class OnExportHighlights(val bookId: String) : ViewHighlightsAction
+    data class OnDeleteHighlight(val highlightId: String) : ViewHighlightsAction
 }
 
 internal sealed interface ViewHighlightsEffect {

--- a/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModelTest.kt
+++ b/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModelTest.kt
@@ -192,7 +192,7 @@ class ViewHighlightsViewModelTest {
         }
 
         this.testScheduler.advanceUntilIdle()
-        assertEquals("test-highlight-id", fakeHighlightsRepository.deletedHighlight?.id)
+        assertEquals("test-highlight-id", fakeHighlightsRepository.deletedHighlightId)
     }
 
     @Test

--- a/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModelTest.kt
+++ b/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModelTest.kt
@@ -155,7 +155,7 @@ class ViewHighlightsViewModelTest {
     }
 
     @Test
-    fun `when highlight onDelete is called then sets loading state`() = runTest {
+    fun `when delete action is processed then sets loading state`() = runTest {
         val bookId = "test-book-id"
         fakeHighlightsRepository.shouldGetAllHighlightsForBookFromDbThrowException = false
 
@@ -166,14 +166,16 @@ class ViewHighlightsViewModelTest {
             awaitItem()
             val stateWithHighlights = awaitItem()
 
-            stateWithHighlights.highlights.first().onDelete()
+            viewModel.processAction(
+                ViewHighlightsAction.OnDeleteHighlight(stateWithHighlights.highlights.first().id)
+            )
             val loadingState = awaitItem()
             assertTrue(loadingState.isLoading)
         }
     }
 
     @Test
-    fun `when highlight delete succeeds then passes highlight to repository`() = runTest {
+    fun `when delete action succeeds then passes highlight to repository`() = runTest {
         val bookId = "test-book-id"
         fakeHighlightsRepository.shouldGetAllHighlightsForBookFromDbThrowException = false
 
@@ -182,7 +184,9 @@ class ViewHighlightsViewModelTest {
 
         viewModel.highlightsUIStateFlow.test {
             val state = awaitItem()
-            state.highlights.first().onDelete()
+            viewModel.processAction(
+                ViewHighlightsAction.OnDeleteHighlight(state.highlights.first().id)
+            )
 
             awaitItem()
         }
@@ -192,7 +196,7 @@ class ViewHighlightsViewModelTest {
     }
 
     @Test
-    fun `when highlight delete fails then shows error message`() = runTest {
+    fun `when delete action fails then shows error message`() = runTest {
         val bookId = "test-book-id"
         fakeHighlightsRepository.shouldGetAllHighlightsForBookFromDbThrowException = false
         fakeHighlightsRepository.shouldDeleteHighlightFromDbThrowException = true
@@ -201,7 +205,11 @@ class ViewHighlightsViewModelTest {
         this.testScheduler.advanceUntilIdle()
 
         viewModel.effects.test {
-            viewModel.highlightsUIStateFlow.value.highlights.first().onDelete()
+            viewModel.processAction(
+                ViewHighlightsAction.OnDeleteHighlight(
+                    viewModel.highlightsUIStateFlow.value.highlights.first().id
+                )
+            )
 
             assertEquals(
                 ViewHighlightsEffect.ShowMessage(R.string.delete_error_message),

--- a/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/fakes/FakeHighlightsRepository.kt
+++ b/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/fakes/FakeHighlightsRepository.kt
@@ -10,7 +10,7 @@ class FakeHighlightsRepository : HighlightsRepository {
     var shouldGetAllHighlightsForBookFromDbThrowException = false
     var shouldDeleteHighlightFromDbThrowException = false
     var bookIdPassed: String? = null
-    var deletedHighlight: Highlight? = null
+    var deletedHighlightId: String? = null
 
     private val fakeHighlight = Highlight(
         id = "test-highlight-id",
@@ -36,8 +36,8 @@ class FakeHighlightsRepository : HighlightsRepository {
         }
     }
 
-    override suspend fun deleteHighlightFromDb(highlight: Highlight): Result<Unit> {
-        deletedHighlight = highlight
+    override suspend fun deleteHighlightFromDb(highlightId: String): Result<Unit> {
+        deletedHighlightId = highlightId
         return if (shouldDeleteHighlightFromDbThrowException) {
             Result.failure(RuntimeException("Delete highlight failed"))
         } else {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ okhttp-version = "5.3.2"
 kotlinx-serialization-version = "1.11.0"
 cropify-version = "0.5.2"
 coil-version = "2.7.0"
+kotlinx-collections-immutable-version = "0.4.0"
 
 junit-version = "4.13.2"
 android-junit-version = "1.3.0"
@@ -69,6 +70,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 retrofit-kotlinx-serialization-converter = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit-version" }
 cropify = { group = "com.github.moyuruaizawa", name = "cropify", version.ref = "cropify-version" }
 coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil-version" }
+kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable-version" }
 
 junit = { group = "junit", name = "junit", version.ref = "junit-version" }
 android-junit = { group = "androidx.test.ext", name = "junit", version.ref = "android-junit-version" }


### PR DESCRIPTION
## Summary

- `AppTheme` ColorScheme now wrapped in `remember(context, useDarkTheme, isDynamicThemeAvailable)` — was rebuilt on every recomposition before this.
- `gradientPlaceholder` `BrushPainter` now `remember`ed per `surface`/`surfaceVariant` color — was allocated per-frame.
- `CropImageScreen`: rotated bitmap decoded off main thread via `produceState(key1 = imageUri)`; shows the existing URI-based Cropify fallback while decoding (no new visible state — matches the pre-existing null-handling path).
- `feature-bookshelf`, `feature-searchbooks`, `feature-viewhighlights`: `List<T>` → `ImmutableList<T>` in all UI-state data classes so Compose strong-skipping can structurally compare and skip unchanged subtrees.
- `HighlightUIState.onDelete: () -> Unit` removed (per-row mutable lambda defeats structural equality); delete now routes through `ViewHighlightsAction.OnDeleteHighlight(highlightId)` → `processAction`.
- `BookUIState.viewBook` / `BookshelfViewModel.viewHighlightsForBook` removed as dead code — `BookshelfScreen` already calls `goToHighlight(bookUIState.id)` directly.

No user-facing behavior changes.

## Test Plan

- `./gradlew assembleDebug` — BUILD SUCCESSFUL (all modules)
- `./gradlew test` — BUILD SUCCESSFUL (all unit tests pass, including updated delete tests in `feature-viewhighlights` and bookshelf tests with `ImmutableList` assertions)
- Smoke: verify bookshelf loads, highlight delete dialog still works, search results appear, crop screen renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)