### PR TITLE
refactor: Compose recomposition tier-3 cleanup

### DIFF
--- a/core-design/src/main/kotlin/com/sriniketh/core_design/ui/components/NavigationBack.kt
+++ b/core-design/src/main/kotlin/com/sriniketh/core_design/ui/components/NavigationBack.kt
@@ -3,13 +3,20 @@ package com.sriniketh.core_design.ui.components
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.sriniketh.core_design.R
 
 @Composable
-fun NavigationBack(action: () -> Unit) {
-    IconButton(onClick = action) {
+fun NavigationBack(
+    modifier: Modifier = Modifier,
+    action: () -> Unit
+) {
+    IconButton(
+        onClick = action,
+        modifier = modifier
+    ) {
         Icon(
             painter = painterResource(R.drawable.ic_arrow_back),
             contentDescription = stringResource(id = R.string.nav_back_arrow_cont_desc)

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
@@ -165,7 +165,9 @@ internal fun Bookshelf(
                                 .padding(12.dp)
                                 .align(Alignment.Start)
                         ) {
-                            val uri = bookUIState.thumbnailLink?.buildHttpsUri()
+                            val uri = remember(bookUIState.thumbnailLink) {
+                                bookUIState.thumbnailLink?.buildHttpsUri()
+                            }
                             AsyncImage(
                                 modifier = modifier
                                     .padding(6.dp)
@@ -188,9 +190,12 @@ internal fun Bookshelf(
                                     text = bookUIState.title,
                                     style = MaterialTheme.typography.titleLarge
                                 )
+                                val authorsLine = remember(bookUIState.authors) {
+                                    bookUIState.authors.joinToString(", ")
+                                }
                                 Text(
                                     modifier = modifier.padding(6.dp),
-                                    text = bookUIState.authors.joinToString(", "),
+                                    text = authorsLine,
                                     style = MaterialTheme.typography.bodyLarge
                                 )
                             }

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -152,7 +152,7 @@ internal fun Bookshelf(
                     .fillMaxSize()
                     .padding(contentPadding)
             ) {
-                itemsIndexed(uiState.books, key = { _, book -> book.id }) { _, bookUIState ->
+                items(uiState.books, key = { it.id }) { bookUIState ->
                     Card(
                         modifier = modifier
                             .fillMaxWidth()

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -157,7 +157,9 @@ private fun BookInfoLayout(
                     .padding(12.dp)
                     .align(Alignment.Start)
             ) {
-                val uri = bookInfo.thumbnailLink?.buildHttpsUri()
+                val uri = remember(bookInfo.thumbnailLink) {
+                    bookInfo.thumbnailLink?.buildHttpsUri()
+                }
                 AsyncImage(
                     modifier = modifier
                         .padding(6.dp)
@@ -177,9 +179,12 @@ private fun BookInfoLayout(
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
                     Column {
+                        val authorsLine = remember(bookInfo.authors) {
+                            bookInfo.authors.joinToString(", ")
+                        }
                         Text(
                             modifier = modifier.padding(6.dp),
-                            text = bookInfo.authors.joinToString(", "),
+                            text = authorsLine,
                             style = MaterialTheme.typography.titleLarge
                         )
                         bookInfo.publisher?.let { publisher ->

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -114,7 +114,7 @@ internal fun BookInfo(
         topBar = {
             ProseTopAppBar(
                 title = { BookInfoScreenTitle(uiState) },
-                navigationIcon = { NavigationBack(goBack) },
+                navigationIcon = { NavigationBack(action = goBack) },
                 scrollBehavior = scrollBehavior
             )
         },

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
@@ -198,7 +198,9 @@ internal fun SearchBook(
                             .fillMaxWidth()
                             .clickable { navigateToBookInfo(item.id) }
                     ) {
-                        val uri = item.thumbnailLink?.buildHttpsUri()
+                        val uri = remember(item.thumbnailLink) {
+                            item.thumbnailLink?.buildHttpsUri()
+                        }
                         AsyncImage(
                             modifier = modifier
                                 .padding(6.dp)
@@ -221,9 +223,12 @@ internal fun SearchBook(
                                 text = item.title,
                                 style = MaterialTheme.typography.bodyLarge
                             )
+                            val authorsLine = remember(item.authors) {
+                                item.authors.joinToString(", ")
+                            }
                             Text(
                                 modifier = modifier.padding(6.dp),
-                                text = item.authors.joinToString(", "),
+                                text = authorsLine,
                                 style = MaterialTheme.typography.bodyMedium
                             )
                             Text(

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -190,7 +190,7 @@ internal fun SearchBook(
                     .fillMaxSize()
                     .testTag("SearchResultsList")
             ) {
-                itemsIndexed(uiState.bookUiStates, key = { _, item -> item.id }) { _, item ->
+                items(uiState.bookUiStates, key = { it.id }) { item ->
                     Row(
                         modifier = modifier
                             .padding(12.dp)

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -238,10 +238,10 @@ internal fun ViewHighlights(
 
                     var expandDropDownMenu by remember { mutableStateOf(false) }
                     val shortenHighlightText = remember(highlightUiState.text) { highlightUiState.text.length > 250 }
-                    val clipboardData = ClipData.newPlainText(
-                        stringResource(id = R.string.clipboard_highlight_label),
-                        highlightUiState.text
-                    )
+                    val clipboardLabel = stringResource(id = R.string.clipboard_highlight_label)
+                    val clipboardData = remember(clipboardLabel, highlightUiState.text) {
+                        ClipData.newPlainText(clipboardLabel, highlightUiState.text)
+                    }
                     var highlightText by remember {
                         if (shortenHighlightText) {
                             mutableStateOf(highlightUiState.text.take(250) + " ...")

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -237,7 +237,7 @@ internal fun ViewHighlights(
                     }
 
                     var expandDropDownMenu by remember { mutableStateOf(false) }
-                    val shortenHighlightText by remember { derivedStateOf { highlightUiState.text.length > 250 } }
+                    val shortenHighlightText = remember(highlightUiState.text) { highlightUiState.text.length > 250 }
                     val clipboardData = ClipData.newPlainText(
                         stringResource(id = R.string.clipboard_highlight_label),
                         highlightUiState.text


### PR DESCRIPTION
## Summary

- Drop `derivedStateOf` misuse on `String.length` in `ViewHighlightsScreen` — replaced with `remember(text) { ... }`
- Memoize per-row allocations in `ViewHighlightsScreen`, `BookshelfScreen`, `SearchBookScreen`, and `BookInfoScreen`: `ClipData.newPlainText`, `buildHttpsUri()`, and `joinToString` wrapped in `remember(key) { ... }`
- Add `modifier: Modifier = Modifier` to `NavigationBack` (modifier first, action last — required for trailing lambda compat); updated one positional call site in `BookInfoScreen` to `NavigationBack(action = goBack)`
- Replace `itemsIndexed` with `items` in `BookshelfScreen` and `SearchBookScreen` where the index was discarded

No user-facing behavior change. Full build and unit tests pass.

## Test plan
- `./gradlew assembleDebug` — BUILD SUCCESSFUL
- `./gradlew test` — all tests pass