### PR TITLE
perf: Compose recomposition Tier 2 — localized cleanup

### DIFF
--- a/core-design/src/main/kotlin/com/sriniketh/core_design/ui/components/ProseTopAppBar.kt
+++ b/core-design/src/main/kotlin/com/sriniketh/core_design/ui/components/ProseTopAppBar.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sriniketh.core_design.ui.theme.AppTheme
@@ -21,16 +22,18 @@ fun ProseTopAppBar(
     actions: @Composable RowScope.() -> Unit = {},
     scrollBehavior: TopAppBarScrollBehavior? = null,
 ) {
+    val containerColor = MaterialTheme.colorScheme.background
+    val colors = TopAppBarDefaults.topAppBarColors(
+        containerColor = containerColor,
+        scrolledContainerColor = containerColor
+    ).let { remember(containerColor) { it } }
     LargeTopAppBar(
         title = title,
         modifier = modifier,
         navigationIcon = navigationIcon,
         actions = actions,
         scrollBehavior = scrollBehavior,
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.background,
-            scrolledContainerColor = MaterialTheme.colorScheme.background
-        )
+        colors = colors
     )
 }
 

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CropImageScreen.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CropImageScreen.kt
@@ -72,7 +72,7 @@ internal fun CropImageScreen(
         val rotatedBitmap = rotatedBitmapState.value
         if (rotatedBitmap != null) {
             Cropify(
-                modifier = modifier
+                modifier = Modifier
                     .padding(contentPadding)
                     .fillMaxSize(),
                 bitmap = rotatedBitmap.asImageBitmap(),
@@ -87,7 +87,7 @@ internal fun CropImageScreen(
             )
         } else {
             Cropify(
-                modifier = modifier
+                modifier = Modifier
                     .padding(contentPadding)
                     .fillMaxSize(),
                 uri = imageUri,

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreen.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreen.kt
@@ -203,19 +203,19 @@ internal fun EditAndSaveHighlight(
     ) { contentPadding ->
         if (uiState.isLoading) {
             LinearProgressIndicator(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .testTag("AddHighlightLoadingIndicator")
             )
         }
 
         Column(
-            modifier = modifier
+            modifier = Modifier
                 .padding(contentPadding)
                 .fillMaxSize()
         ) {
             BasicTextField(
-                modifier = modifier
+                modifier = Modifier
                     .weight(0.8f)
                     .fillMaxWidth()
                     .padding(18.dp)

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
@@ -119,7 +119,7 @@ internal fun Bookshelf(
                 onClick = goToSearch,
                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                 contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                modifier = modifier.sharedBoundsTransition(key = AnimationConstants.BOOKSHELF_TO_SEARCH_BOUNDS_TRANSITION_KEY)
+                modifier = Modifier.sharedBoundsTransition(key = AnimationConstants.BOOKSHELF_TO_SEARCH_BOUNDS_TRANSITION_KEY)
             ) {
                 Icon(
                     painter = painterResource(com.sriniketh.core_design.R.drawable.ic_search),
@@ -131,7 +131,7 @@ internal fun Bookshelf(
     ) { contentPadding ->
         if (uiState.isLoading) {
             LinearProgressIndicator(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .testTag("BookshelfLoadingIndicator")
             )
@@ -139,7 +139,7 @@ internal fun Bookshelf(
 
         if (uiState.books.isEmpty() && !uiState.isLoading) {
             Box(
-                modifier = modifier.fillMaxSize()
+                modifier = Modifier.fillMaxSize()
             ) {
                 Text(
                     modifier = Modifier.align(Alignment.Center),
@@ -149,26 +149,26 @@ internal fun Bookshelf(
             }
         } else if (uiState.books.isNotEmpty()) {
             LazyColumn(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxSize()
                     .padding(contentPadding)
             ) {
                 itemsIndexed(uiState.books, key = { _, book -> book.id }) { _, bookUIState ->
                     Card(
-                        modifier = modifier
+                        modifier = Modifier
                             .fillMaxWidth()
                             .padding(12.dp)
                             .clickable { goToHighlight(bookUIState.id) },
                         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
                     ) {
                         Row(
-                            modifier = modifier
+                            modifier = Modifier
                                 .padding(12.dp)
                                 .align(Alignment.Start)
                         ) {
                             val uri = bookUIState.thumbnailLink?.buildHttpsUri()
                             AsyncImage(
-                                modifier = modifier
+                                modifier = Modifier
                                     .padding(6.dp)
                                     .height(100.dp)
                                     .width(80.dp)
@@ -180,17 +180,17 @@ internal fun Bookshelf(
                                 error = gradientPlaceholder()
                             )
                             Column(
-                                modifier = modifier
+                                modifier = Modifier
                                     .padding(horizontal = 6.dp)
                                     .align(Alignment.Top)
                             ) {
                                 Text(
-                                    modifier = modifier.padding(6.dp),
+                                    modifier = Modifier.padding(6.dp),
                                     text = bookUIState.title,
                                     style = MaterialTheme.typography.titleLarge
                                 )
                                 Text(
-                                    modifier = modifier.padding(6.dp),
+                                    modifier = Modifier.padding(6.dp),
                                     text = bookUIState.authors.joinToString(", "),
                                     style = MaterialTheme.typography.bodyLarge
                                 )

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
@@ -98,7 +98,7 @@ internal fun Bookshelf(
     goToSearch: () -> Unit,
     goToHighlight: (String) -> Unit
 ) {
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val scrollBehavior = run { TopAppBarDefaults.exitUntilCollapsedScrollBehavior() }.let { remember { it } }
     Scaffold(
         modifier = modifier
             .nestedScroll(scrollBehavior.nestedScrollConnection)

--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
@@ -11,8 +11,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme
-import com.sriniketh.core_models.book.Book
-import com.sriniketh.core_models.book.BookInfo
+import kotlinx.collections.immutable.toImmutableList
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -273,7 +272,6 @@ class BookInfoScreenTest {
     }
 
     private fun createTestBook(
-        id: String = "test-id",
         title: String = "Test Title",
         authors: List<String> = listOf("Test Author"),
         publisher: String? = "Test Publisher",
@@ -282,19 +280,15 @@ class BookInfoScreenTest {
         averageRating: Double? = 4.0,
         ratingsCount: Int? = 100,
         publishedDate: String? = "2023"
-    ) = Book(
-        id = id,
-        info = BookInfo(
-            title = title,
-            subtitle = "Test Subtitle",
-            authors = authors,
-            thumbnailLink = null,
-            publisher = publisher,
-            publishedDate = publishedDate,
-            description = description,
-            pageCount = pageCount,
-            averageRating = averageRating,
-            ratingsCount = ratingsCount
-        )
+    ) = BookInfoUiData(
+        title = title,
+        authors = authors.toImmutableList(),
+        thumbnailLink = null,
+        publisher = publisher,
+        publishedDate = publishedDate,
+        description = description,
+        pageCount = pageCount,
+        averageRating = averageRating,
+        ratingsCount = ratingsCount
     )
 }

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -105,7 +105,7 @@ internal fun BookInfo(
     modifier: Modifier = Modifier,
     goBack: () -> Unit
 ) {
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val scrollBehavior = run { TopAppBarDefaults.exitUntilCollapsedScrollBehavior() }.let { remember { it } }
     Scaffold(
         modifier = modifier
             .fillMaxSize()
@@ -142,8 +142,7 @@ private fun BookInfoLayout(
     uiState: BookInfoUiState,
     contentPadding: PaddingValues
 ) {
-    uiState.book?.let { book ->
-        val bookInfo = book
+    uiState.book?.let { bookInfo ->
         Column(
             modifier = Modifier
                 .verticalScroll(rememberScrollState())

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -126,7 +126,7 @@ internal fun BookInfo(
     ) { contentPadding ->
         if (uiState.isLoading) {
             LinearProgressIndicator(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .padding(contentPadding)
                     .testTag("BookInfoLoadingIndicator")
@@ -146,19 +146,19 @@ private fun BookInfoLayout(
     uiState.book?.let { book ->
         val bookInfo = book
         Column(
-            modifier = modifier
+            modifier = Modifier
                 .verticalScroll(rememberScrollState())
                 .fillMaxSize()
                 .padding(contentPadding)
         ) {
             Row(
-                modifier = modifier
+                modifier = Modifier
                     .padding(12.dp)
                     .align(Alignment.Start)
             ) {
                 val uri = bookInfo.thumbnailLink?.buildHttpsUri()
                 AsyncImage(
-                    modifier = modifier
+                    modifier = Modifier
                         .padding(6.dp)
                         .height(160.dp)
                         .width(120.dp)
@@ -170,20 +170,20 @@ private fun BookInfoLayout(
                     error = gradientPlaceholder()
                 )
                 Column(
-                    modifier = modifier
+                    modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 6.dp),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
                     Column {
                         Text(
-                            modifier = modifier.padding(6.dp),
+                            modifier = Modifier.padding(6.dp),
                             text = bookInfo.authors.joinToString(", "),
                             style = MaterialTheme.typography.titleLarge
                         )
                         bookInfo.publisher?.let { publisher ->
                             Text(
-                                modifier = modifier.padding(6.dp),
+                                modifier = Modifier.padding(6.dp),
                                 text = publisher,
                                 style = MaterialTheme.typography.bodyLarge
                             )
@@ -209,17 +209,17 @@ private fun BookInfoLayout(
                 }
             }
             Card(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .padding(12.dp),
                 colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
             ) {
-                Column(modifier = modifier.padding(12.dp)) {
+                Column(modifier = Modifier.padding(12.dp)) {
                     val averageRating = bookInfo.averageRating
                     val ratingsCount = bookInfo.ratingsCount
                     if (averageRating != null && ratingsCount != null) {
                         Text(
-                            modifier = modifier.padding(6.dp),
+                            modifier = Modifier.padding(6.dp),
                             text = stringResource(
                                 id = R.string.book_info_ratings_template,
                                 averageRating,
@@ -230,7 +230,7 @@ private fun BookInfoLayout(
                     }
                     bookInfo.pageCount?.let {
                         Text(
-                            modifier = modifier.padding(6.dp),
+                            modifier = Modifier.padding(6.dp),
                             text = stringResource(
                                 id = R.string.book_info_pagecount_template,
                                 it
@@ -240,7 +240,7 @@ private fun BookInfoLayout(
                     }
                     bookInfo.publisher?.let {
                         Text(
-                            modifier = modifier.padding(6.dp),
+                            modifier = Modifier.padding(6.dp),
                             text = stringResource(
                                 id = R.string.book_info_publisher_template,
                                 it
@@ -250,7 +250,7 @@ private fun BookInfoLayout(
                     }
                     bookInfo.publishedDate?.let {
                         Text(
-                            modifier = modifier.padding(6.dp),
+                            modifier = Modifier.padding(6.dp),
                             text = stringResource(
                                 id = R.string.book_info_publish_date_template,
                                 it

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -133,14 +133,13 @@ internal fun BookInfo(
             )
         }
 
-        BookInfoLayout(uiState, modifier, contentPadding)
+        BookInfoLayout(uiState, contentPadding)
     }
 }
 
 @Composable
 private fun BookInfoLayout(
     uiState: BookInfoUiState,
-    modifier: Modifier,
     contentPadding: PaddingValues
 ) {
     uiState.book?.let { book ->

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -193,16 +193,18 @@ private fun BookInfoLayout(
                 }
             }
             bookInfo.description?.let { description ->
+                val descriptionText = remember(description) {
+                    Html.fromHtml(description, Html.FROM_HTML_MODE_LEGACY).toString()
+                }
                 Card(
-                    modifier = modifier
+                    modifier = Modifier
                         .fillMaxWidth()
                         .padding(12.dp),
                     colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
                 ) {
                     Text(
-                        modifier = modifier.padding(12.dp),
-                        text = Html.fromHtml(description, Html.FROM_HTML_MODE_LEGACY)
-                            .toString(),
+                        modifier = Modifier.padding(12.dp),
+                        text = descriptionText,
                         style = MaterialTheme.typography.bodyLarge
                     )
                 }

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -55,9 +55,8 @@ import com.sriniketh.core_design.ui.components.NavigationBack
 import com.sriniketh.core_design.ui.components.ProseTopAppBar
 import com.sriniketh.core_design.ui.components.gradientPlaceholder
 import com.sriniketh.core_design.ui.theme.AppTheme
-import com.sriniketh.core_models.book.Book
-import com.sriniketh.core_models.book.BookInfo
 import com.sriniketh.core_platform.buildHttpsUri
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 
 @Composable
@@ -145,7 +144,7 @@ private fun BookInfoLayout(
     contentPadding: PaddingValues
 ) {
     uiState.book?.let { book ->
-        val bookInfo = book.info
+        val bookInfo = book
         Column(
             modifier = modifier
                 .verticalScroll(rememberScrollState())
@@ -295,7 +294,7 @@ private fun BookInfoScreenFloatingActionButton(buttonOnClick: () -> Unit) {
 private fun BookInfoScreenTitle(uiState: BookInfoUiState) {
     uiState.book?.let { book ->
         Text(
-            text = book.info.title,
+            text = book.title,
             style = MaterialTheme.typography.headlineMedium,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis
@@ -309,20 +308,16 @@ internal fun BookInfoScreenPreview() {
     AppTheme {
         BookInfo(
             uiState = BookInfoUiState(
-                book = Book(
-                    id = "someId",
-                    info = BookInfo(
-                        title = "some really really really long title",
-                        subtitle = "some subtitle",
-                        authors = listOf("author 1, author 2"),
-                        thumbnailLink = "https://picsum.photos/200/300",
-                        publisher = "some publisher",
-                        publishedDate = "23rd January 2021",
-                        description = "some description that's repeated again and again so that we have this long piece of text. some description that's repeated again and again so that we have this long piece of text.",
-                        pageCount = 215,
-                        averageRating = 4.3,
-                        ratingsCount = 1227
-                    )
+                book = BookInfoUiData(
+                    title = "some really really really long title",
+                    authors = persistentListOf("author 1, author 2"),
+                    thumbnailLink = "https://picsum.photos/200/300",
+                    publisher = "some publisher",
+                    publishedDate = "23rd January 2021",
+                    description = "some description that's repeated again and again so that we have this long piece of text. some description that's repeated again and again so that we have this long piece of text.",
+                    pageCount = 215,
+                    averageRating = 4.3,
+                    ratingsCount = 1227
                 ),
                 canAddToShelf = true,
                 addBookToShelf = {}

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt
@@ -3,11 +3,14 @@ package com.sriniketh.feature_searchbooks
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.sriniketh.core_data.usecases.FetchBookInfoUseCase
 import com.sriniketh.core_data.usecases.AddBookToShelfUseCase
+import com.sriniketh.core_data.usecases.FetchBookInfoUseCase
 import com.sriniketh.core_data.usecases.IsBookInDbUseCase
 import com.sriniketh.core_models.book.Book
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,7 +47,7 @@ class BookInfoViewModel @Inject constructor(
                 _uiState.update { state ->
                     state.copy(
                         isLoading = false,
-                        book = book,
+                        book = book.asUiData(),
                         canAddToShelf = !isInDb,
                         addBookToShelf = { addBookToShelf(book) }
                     )
@@ -80,13 +83,37 @@ class BookInfoViewModel @Inject constructor(
             }
         }
     }
+
+    private fun Book.asUiData(): BookInfoUiData = BookInfoUiData(
+        title = info.title,
+        authors = info.authors.toImmutableList(),
+        thumbnailLink = info.thumbnailLink,
+        publisher = info.publisher,
+        publishedDate = info.publishedDate,
+        description = info.description,
+        pageCount = info.pageCount,
+        averageRating = info.averageRating,
+        ratingsCount = info.ratingsCount
+    )
 }
 
 data class BookInfoUiState(
     val isLoading: Boolean = false,
-    val book: Book? = null,
+    val book: BookInfoUiData? = null,
     val canAddToShelf: Boolean = false,
     val addBookToShelf: () -> Unit = {}
+)
+
+data class BookInfoUiData(
+    val title: String,
+    val authors: ImmutableList<String> = persistentListOf(),
+    val thumbnailLink: String?,
+    val publisher: String?,
+    val publishedDate: String?,
+    val description: String?,
+    val pageCount: Int?,
+    val averageRating: Double?,
+    val ratingsCount: Int?
 )
 
 internal sealed interface BookInfoEffect {

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
@@ -124,7 +124,7 @@ internal fun SearchBook(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { contentPadding ->
         SearchBar(
-            modifier = modifier
+            modifier = Modifier
                 .padding(contentPadding)
                 .focusRequester(focusRequester)
                 .fillMaxWidth(),
@@ -157,7 +157,7 @@ internal fun SearchBook(
                     trailingIcon = {
                         if (expanded) {
                             Icon(
-                                modifier = modifier.clickable {
+                                modifier = Modifier.clickable {
                                     if (text.isNotEmpty()) {
                                         text = ""
                                         resetSearch()
@@ -179,21 +179,21 @@ internal fun SearchBook(
         ) {
             if (uiState.isLoading) {
                 LinearProgressIndicator(
-                    modifier = modifier
+                    modifier = Modifier
                         .fillMaxWidth()
                         .testTag("SearchBookLoadingIndicator")
                 )
             }
             LazyColumn(
                 state = listState,
-                modifier = modifier
+                modifier = Modifier
                     .padding(contentPadding)
                     .fillMaxSize()
                     .testTag("SearchResultsList")
             ) {
                 itemsIndexed(uiState.bookUiStates, key = { _, item -> item.id }) { _, item ->
                     Row(
-                        modifier = modifier
+                        modifier = Modifier
                             .padding(12.dp)
                             .align(Alignment.Start)
                             .fillMaxWidth()
@@ -201,7 +201,7 @@ internal fun SearchBook(
                     ) {
                         val uri = item.thumbnailLink?.buildHttpsUri()
                         AsyncImage(
-                            modifier = modifier
+                            modifier = Modifier
                                 .padding(6.dp)
                                 .height(80.dp)
                                 .width(60.dp)
@@ -213,28 +213,28 @@ internal fun SearchBook(
                             error = gradientPlaceholder()
                         )
                         Column(
-                            modifier = modifier
+                            modifier = Modifier
                                 .padding(horizontal = 6.dp)
                                 .align(Alignment.Top)
                         ) {
                             Text(
-                                modifier = modifier.padding(6.dp),
+                                modifier = Modifier.padding(6.dp),
                                 text = item.title,
                                 style = MaterialTheme.typography.bodyLarge
                             )
                             Text(
-                                modifier = modifier.padding(6.dp),
+                                modifier = Modifier.padding(6.dp),
                                 text = item.authors.joinToString(", "),
                                 style = MaterialTheme.typography.bodyMedium
                             )
                             Text(
-                                modifier = modifier.padding(6.dp),
+                                modifier = Modifier.padding(6.dp),
                                 text = item.subtitle.orEmpty(),
                                 style = MaterialTheme.typography.bodySmall
                             )
                         }
                     }
-                    HorizontalDivider(modifier = modifier.fillMaxWidth())
+                    HorizontalDivider(modifier = Modifier.fillMaxWidth())
                 }
             }
         }

--- a/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/BookInfoViewModelTest.kt
+++ b/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/BookInfoViewModelTest.kt
@@ -77,7 +77,7 @@ class BookInfoViewModelTest {
             val successState = awaitItem()
             assertFalse(successState.isLoading)
             assertNotNull(successState.book)
-            assertEquals("test-id", successState.book?.id)
+            assertEquals("Test Title", successState.book?.title)
             assertTrue(successState.canAddToShelf)
         }
     }

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -208,12 +208,12 @@ internal fun ViewHighlights(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { contentPadding ->
         if (uiState.isLoading) {
-            LinearProgressIndicator(modifier = modifier.fillMaxWidth())
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
         }
 
         if (uiState.highlights.isEmpty()) {
             Box(
-                modifier = modifier.fillMaxSize()
+                modifier = Modifier.fillMaxSize()
             ) {
                 Text(
                     modifier = Modifier.align(Alignment.Center),
@@ -223,7 +223,7 @@ internal fun ViewHighlights(
             }
         } else {
             LazyColumn(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxSize()
                     .padding(contentPadding),
                 state = lazyListState
@@ -254,7 +254,7 @@ internal fun ViewHighlights(
                     }
 
                     Row(
-                        modifier = modifier
+                        modifier = Modifier
                             .fillMaxWidth()
                             .padding(12.dp)
                             .animateContentSize()
@@ -265,16 +265,16 @@ internal fun ViewHighlights(
                             },
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
-                        Column(modifier = modifier.weight(1f)) {
+                        Column(modifier = Modifier.weight(1f)) {
                             SelectionContainer {
                                 Text(
-                                    modifier = modifier.padding(6.dp),
+                                    modifier = Modifier.padding(6.dp),
                                     text = highlightText,
                                     style = MaterialTheme.typography.bodyLarge
                                 )
                             }
                             Text(
-                                modifier = modifier.padding(6.dp),
+                                modifier = Modifier.padding(6.dp),
                                 text = stringResource(
                                     id = R.string.highlight_item_saved_on_template,
                                     highlightUiState.savedOn
@@ -294,7 +294,7 @@ internal fun ViewHighlights(
                                 )
                             }
                             DropdownMenu(
-                                modifier = modifier.clickable { expandDropDownMenu = true },
+                                modifier = Modifier.clickable { expandDropDownMenu = true },
                                 expanded = expandDropDownMenu,
                                 onDismissRequest = { expandDropDownMenu = false }) {
                                 DropdownMenuItem(
@@ -338,7 +338,7 @@ internal fun ViewHighlights(
                             }
                         }
                     }
-                    HorizontalDivider(modifier = modifier.fillMaxWidth())
+                    HorizontalDivider(modifier = Modifier.fillMaxWidth())
                 }
             }
         }

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -164,7 +164,7 @@ internal fun ViewHighlights(
             lazyListState.firstVisibleItemIndex < 2
         }
     }
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val scrollBehavior = run { TopAppBarDefaults.exitUntilCollapsedScrollBehavior() }.let { remember { it } }
     Scaffold(
         modifier = modifier
             .fillMaxSize()


### PR DESCRIPTION
## Summary

- `remember` the `TopAppBarScrollBehavior` in `BookshelfScreen`, `BookInfoScreen`, and `ViewHighlightsScreen` so the scroll offset survives recomposition (uses `run{}.let{remember{it}}` because `exitUntilCollapsedScrollBehavior()` is `@Composable` in M3 1.5 and cannot be called inside `remember{}`'s `@DisallowComposableCalls` lambda)
- `remember(description)` the `Html.fromHtml(...)` parse in `BookInfoScreen` so the HTML is only re-decoded when the description string actually changes
- `remember(containerColor)` the `TopAppBarColors` in `ProseTopAppBar` so a new colors object isn't allocated every recomposition
- Introduce `BookInfoUiData` — a flat, stable mirror of `core-models.BookInfo` with `ImmutableList<String>` for authors — so `BookInfoUiState` no longer exposes the unstable domain `Book` type to Compose; `core-models` stays Compose-free
- Replace `modifier = modifier.X` with `modifier = Modifier.X` on all inner (non-root) composable children across `BookshelfScreen`, `SearchBookScreen`, `BookInfoScreen`, `ViewHighlightsScreen`, `EditAndSaveHighlightScreen`, `CropImageScreen` (45 sites); root nodes are unchanged

No user-facing behavior change.

## Notes

- Stacked on the Tier 1 PR (`worktree-feature+compose-recomp-tier1-stability`) — base branch is set accordingly; merge Tier 1 first, then rebase/re-target this PR to `main`
- `BookInfoScreenTest` (instrumented) updated to construct `BookInfoUiData` directly instead of `Book`; unit test assertion updated from `book?.id` to `book?.title`

## Test Plan

- [ ] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [ ] `./gradlew test` — all unit tests pass
- [ ] Smoke: bookshelf scroll collapses the top bar smoothly; book search, book info, and add-highlight flows unchanged