### PR TITLE
refactor(compose): swap LocalContext.getString for LocalResources in snackbar effect handlers

### DIFF
--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreen.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -58,7 +58,7 @@ fun EditAndSaveHighlightScreen(
     }
     val editHighlightUiState: EditAndSaveHighlightUiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val context = LocalContext.current
+    val resources = LocalResources.current
     val scope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -67,7 +67,7 @@ fun EditAndSaveHighlightScreen(
             viewModel.effects.collect { effect ->
                 when (effect) {
                     is EditAndSaveHighlightEffect.ShowMessage -> scope.launch {
-                        snackbarHostState.showSnackbar(context.getString(effect.messageRes))
+                        snackbarHostState.showSnackbar(resources.getString(effect.messageRes))
                     }
 
                     EditAndSaveHighlightEffect.HighlightSaved -> goBack()
@@ -106,7 +106,7 @@ fun EditAndSaveHighlightScreen(
 
     val editHighlightUiState: EditAndSaveHighlightUiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val context = LocalContext.current
+    val resources = LocalResources.current
     val scope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -115,7 +115,7 @@ fun EditAndSaveHighlightScreen(
             viewModel.effects.collect { effect ->
                 when (effect) {
                     is EditAndSaveHighlightEffect.ShowMessage -> scope.launch {
-                        snackbarHostState.showSnackbar(context.getString(effect.messageRes))
+                        snackbarHostState.showSnackbar(resources.getString(effect.messageRes))
                     }
 
                     EditAndSaveHighlightEffect.HighlightSaved -> goBack()

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -63,7 +63,7 @@ fun BookshelfScreen(
 ) {
     val uiState: BookshelfUIState by viewModel.bookshelfUIState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val context = LocalContext.current
+    val resources = LocalResources.current
     val scope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -72,7 +72,7 @@ fun BookshelfScreen(
             viewModel.effects.collect { effect ->
                 when (effect) {
                     is BookshelfEffect.ShowMessage -> scope.launch {
-                        snackbarHostState.showSnackbar(context.getString(effect.messageRes))
+                        snackbarHostState.showSnackbar(resources.getString(effect.messageRes))
                     }
                 }
             }

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
@@ -73,7 +73,7 @@ fun BookInfoScreen(
     }
     val uiState: BookInfoUiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val context = LocalContext.current
+    val resources = LocalResources.current
     val scope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -82,7 +82,7 @@ fun BookInfoScreen(
             viewModel.effects.collect { effect ->
                 when (effect) {
                     is BookInfoEffect.ShowMessage -> scope.launch {
-                        snackbarHostState.showSnackbar(context.getString(effect.messageRes))
+                        snackbarHostState.showSnackbar(resources.getString(effect.messageRes))
                     }
                     BookInfoEffect.NavigateToBookshelf -> onBookAddedToShelf()
                 }

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -65,7 +65,7 @@ fun SearchBookScreen(
 ) {
     val uiState: BookSearchUiState by viewModel.searchUiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val context = LocalContext.current
+    val resources = LocalResources.current
     val scope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -74,7 +74,7 @@ fun SearchBookScreen(
             viewModel.effects.collect { effect ->
                 when (effect) {
                     is SearchBookEffect.ShowMessage -> scope.launch {
-                        snackbarHostState.showSnackbar(context.getString(effect.messageRes))
+                        snackbarHostState.showSnackbar(resources.getString(effect.messageRes))
                     }
                 }
             }

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.toClipEntry
 import androidx.compose.ui.res.painterResource
@@ -83,7 +83,7 @@ fun ViewHighlightsScreen(
     val uiState: ViewHighlightsUIState by viewModel.highlightsUIStateFlow.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }
-    val context = LocalContext.current
+    val resources = LocalResources.current
     val scope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -96,7 +96,7 @@ fun ViewHighlightsScreen(
             viewModel.effects.collect { effect ->
                 when (effect) {
                     is ViewHighlightsEffect.ShowMessage -> scope.launch {
-                        snackbarHostState.showSnackbar(context.getString(effect.messageRes))
+                        snackbarHostState.showSnackbar(resources.getString(effect.messageRes))
                     }
 
                     is ViewHighlightsEffect.ShareHighlights -> {


### PR DESCRIPTION
## Summary

- Replaces `LocalContext.current` + `context.getString(@StringRes)` with `LocalResources.current` + `resources.getString(@StringRes)` at the six snackbar-effect call sites that read string resources from inside `LaunchedEffect { effects.collect { ... } }` (`SearchBookScreen`, `BookInfoScreen`, `EditAndSaveHighlightScreen` ×2 overloads, `ViewHighlightsScreen`, `BookshelfScreen`).
- Silences the Compose IDE warning `LocalContextGetResourceValueCall` ("Querying resource values using LocalContext.current") at all six sites.
- `stringResource()` can't replace `getString()` here because it's `@Composable` and unreachable from inside the coroutine block; `LocalResources.current` is the warning's other sanctioned alternative and works inside the effect closure.

## Out of scope (deliberately untouched)

- `CropImageScreen.kt` — `LocalContext.current` is used for `contentResolver` / `ImageRotater`, not resource values, so the lint rule doesn't apply.
- `core-design/.../Theme.kt` — `LocalContext.current` feeds `dynamicDarkColorScheme(context)` / `dynamicLightColorScheme(context)`, also not a resource-value call.

## Test plan

- [x] `./gradlew :feature-searchbooks:compileDebugKotlin :feature-bookshelf:compileDebugKotlin :feature-viewhighlights:compileDebugKotlin :feature-addhighlight:compileDebugKotlin` → BUILD SUCCESSFUL
- [x] `./gradlew :feature-searchbooks:test :feature-bookshelf:test :feature-viewhighlights:test :feature-addhighlight:test` → all green
- [x] `./gradlew :feature-searchbooks:lintDebug :feature-bookshelf:lintDebug :feature-viewhighlights:lintDebug :feature-addhighlight:lintDebug` → BUILD SUCCESSFUL, no `LocalContextGetResourceValueCall` in the four reports
- [x] Repo-wide `grep "context.getString"` → no production hits; `grep "LocalContext.current"` → only the two out-of-scope sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)