### PR TITLE
docs: add architecture, modularization, and flow reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,17 @@
 
 This file provides guidance to AI coding agents like Claude Code (claude.ai/code), Cursor AI, Codex, Gemini CLI, GitHub Copilot, and other AI coding assistants when working with code in this repository.
 
+## Documentation
+
+In-depth engineering docs live under [`docs/`](docs/) and are written to be both human- and agent-readable:
+
+- [`docs/README.md`](docs/README.md) — index and fast facts.
+- [`docs/architecture.md`](docs/architecture.md) — layering, the UDF contract, Hilt DI map, navigation, and conventions.
+- [`docs/modules.md`](docs/modules.md) — per-module breakdown, dependency graph, and use-case index.
+- [`docs/flows.md`](docs/flows.md) — end-to-end walkthroughs of every user flow with source paths.
+
+Consult these before making non-trivial changes; the summary below is a quick reference.
+
 ## Build Commands
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# Prose — Engineering Documentation
+
+Prose is a multi-module Android app for capturing and saving highlights from **physical** books.
+You search for a book via the Google Books API, save it to a local bookshelf, then point your
+camera at a page; on-device OCR (ML Kit) turns the photograph into editable highlight text that is
+persisted with Room and can be exported as JSON.
+
+This folder is the canonical reference for how the app is built. It is written to be read by both
+humans and coding agents: every component is named with its concrete file path so it can be located
+with a single search.
+
+## Documents
+
+| Document | What it covers |
+|----------|----------------|
+| [architecture.md](architecture.md) | Layering, the unidirectional data-flow (UDF) contract, dependency injection, navigation, and the cross-cutting conventions every module follows. |
+| [modules.md](modules.md) | Every Gradle module, what it owns, its public surface, and the full inter-module dependency graph. |
+| [flows.md](flows.md) | Step-by-step walkthroughs of each user-facing flow (bootstrap, bookshelf, search, add book, view highlights, capture→OCR→save, export/share) traced from UI down to the data source. |
+
+## Fast facts
+
+- **Language / build:** Kotlin, Gradle (Kotlin DSL), JVM toolchain 17. Versions are centralized in
+  [`gradle/libs.versions.toml`](../gradle/libs.versions.toml).
+- **UI:** Jetpack Compose, Material 3 with dynamic color, Navigation Compose, shared-element transitions.
+- **Async:** Coroutines + Flow. `StateFlow` for screen state, `Channel`/`receiveAsFlow` for one-shot effects.
+- **DI:** Hilt, one `@Module` per layer installed in `SingletonComponent`.
+- **Persistence:** Room (`book-db`) for books and highlights.
+- **Network:** Retrofit 3 + kotlinx.serialization against the Google Books API.
+- **OCR:** ML Kit on-device Latin text recognition.
+- **Min / target / compile SDK:** 26 / 35 / 36.
+- **Entry point:** [`app/.../MainActivity.kt`](../app/src/main/java/com/sriniketh/prose/MainActivity.kt)
+  → [`ProseAppScreen.kt`](../app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt).
+
+## Building
+
+1. Create `core-network/apikey.properties` containing `BOOKS_API_KEY="<your-google-books-api-key>"`.
+2. `./gradlew assembleDebug`
+
+See [`AGENTS.md`](../AGENTS.md) for build/test commands and agent-specific guidance.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,200 @@
+# Architecture
+
+Prose follows **unidirectional data flow (UDF)** with a clean, layered, multi-module structure. Data
+moves in one direction — from data sources up to the UI — and user intent moves back down as method
+calls. The same shape repeats in every feature, so once you understand one screen you understand all
+of them.
+
+```
+ ┌─────────────────────────────────────────────────────────────┐
+ │  Presentation (feature-* modules)                            │
+ │  Compose screen  ⇄  ViewModel (StateFlow + effect Channel)   │
+ └───────────────▲───────────────────────────┬─────────────────┘
+                 │ UiState / Effect           │ UseCase()
+ ┌───────────────┴───────────────────────────▼─────────────────┐
+ │  Domain + Data (core-data)                                   │
+ │  UseCase  →  Repository  →  transformers (DTO/Entity ↔ Model)│
+ └───────────────▲───────────────────────────┬─────────────────┘
+                 │ Result<DomainModel>        │
+ ┌───────────────┴──────────┬────────────────▼─────────────────┐
+ │ core-network (Retrofit)  │ core-db (Room)   │ core-platform  │
+ │ Google Books API         │ book-db          │ files, time    │
+ └──────────────────────────┴──────────────────┴────────────────┘
+```
+
+The canonical pipeline (also stated in `AGENTS.md`):
+
+```
+Network / Database → Repository → UseCase → ViewModel → Compose UI
+```
+
+A feature module **never** talks to `core-network` or `core-db` directly. Its only data dependency
+is `core-data`, which hides the data sources behind repositories and exposes use cases.
+
+---
+
+## Layers
+
+### Domain models — `core-models`
+
+Pure Kotlin (`java-library` + `kotlin-jvm`, no Android dependencies). Holds the three domain types
+that flow through the whole app:
+
+- [`Book` / `BookInfo`](../core-models/src/main/java/com/sriniketh/core_models/book/Book.kt)
+- [`Highlight`](../core-models/src/main/java/com/sriniketh/core_models/book/Highlight.kt)
+- [`BookSearch`](../core-models/src/main/java/com/sriniketh/core_models/search/BookSearch.kt)
+
+These are the lingua franca: network DTOs and Room entities are mapped to/from them at the
+`core-data` boundary, so nothing above `core-data` ever sees a Retrofit or Room type.
+
+### Data sources
+
+| Module | Responsibility | Key types |
+|--------|----------------|-----------|
+| [`core-network`](../core-network) | Google Books API client. | [`BooksApi`](../core-network/src/main/java/com/sriniketh/prose/core_network/retrofit/BooksApi.kt), [`BooksRemoteDataSource`](../core-network/src/main/java/com/sriniketh/prose/core_network/BooksRemoteDataSource.kt), [`Volumes`](../core-network/src/main/java/com/sriniketh/prose/core_network/model/Volumes.kt) DTOs |
+| [`core-db`](../core-db) | Room database `book-db`. | [`BookDatabase`](../core-db/src/main/java/com/sriniketh/core_db/BookDatabase.kt), [`BookDao`](../core-db/src/main/java/com/sriniketh/core_db/dao/BookDao.kt), [`HighlightDao`](../core-db/src/main/java/com/sriniketh/core_db/dao/HighlightDao.kt), entities |
+| [`core-platform`](../core-platform) | OS abstractions that keep `core-data` testable. | [`FileSource`](../core-platform/src/main/java/com/sriniketh/core_platform/FileSource.kt), [`DateTimeSource`](../core-platform/src/main/java/com/sriniketh/core_platform/DateTimeSource.kt), URI/log extensions |
+
+### Repository + domain — `core-data`
+
+The single module that combines the data sources. It contains:
+
+- **Repositories** — [`BooksRepository`](../core-data/src/main/java/com/sriniketh/core_data/BooksRepository.kt)
+  and [`HighlightsRepository`](../core-data/src/main/java/com/sriniketh/core_data/HighlightsRepository.kt)
+  (interfaces) with `*Impl` classes that orchestrate network + db and map DTO/entity ↔ domain model.
+- **Use cases** — single-purpose classes in
+  [`usecases/`](../core-data/src/main/java/com/sriniketh/core_data/usecases) with an
+  `operator fun invoke()`. ViewModels depend on these, not on repositories directly. Most are thin
+  pass-throughs (e.g. `SaveHighlightUseCase`); a few coordinate multiple sources (e.g.
+  `ExportHighlightsUseCase` reads both repositories).
+- **Transformers** — extension functions in
+  [`transformers/`](../core-data/src/main/java/com/sriniketh/core_data/transformers) such as
+  `Volume.asBook()`, `Book.asBookEntity()`, `BookEntity.asBook()` that cross the model boundaries.
+
+### Design system — `core-design`
+
+Shared Compose theme ([`Theme.kt`](../core-design/src/main/kotlin/com/sriniketh/core_design/ui/theme/Theme.kt),
+dynamic color), reusable components (`ProseTopAppBar`, `NavigationBack`, `Placeholder`), typography,
+animation specs, and the
+[`CompositionLocals`](../core-design/src/main/kotlin/com/sriniketh/core_design/ui/CompositionLocals.kt)
+(`LocalSharedTransitionScope`, `LocalAnimatedVisibilityScope`) used for shared-element transitions.
+
+### Presentation — `feature-*` and `app`
+
+Each feature module owns its Compose screens, ViewModels, and feature-local DI. The `app` module
+hosts the single Activity, the navigation graph, and app-level bindings.
+
+---
+
+## The UDF contract
+
+Every ViewModel in the codebase follows the same pattern. Use it as the template when adding a screen.
+
+**State** — an immutable data class exposed as a read-only `StateFlow`:
+
+```kotlin
+private val _uiState = MutableStateFlow(SomeUiState())
+internal val uiState: StateFlow<SomeUiState> = _uiState.asStateFlow()
+```
+
+**Effects** — one-shot events (snackbars, navigation, share sheet) exposed via a buffered `Channel`
+so they fire exactly once and are not replayed on recomposition / config change:
+
+```kotlin
+private val _effects = Channel<SomeEffect>(Channel.BUFFERED)
+internal val effects: Flow<SomeEffect> = _effects.receiveAsFlow()
+```
+
+**Actions** — user intent. Simpler screens expose plain functions (`viewModel.saveHighlight(...)`);
+[`ViewHighlightsViewModel`](../feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModel.kt)
+uses a sealed `ViewHighlightsAction` dispatched through a single `processAction(...)`.
+
+**Collection in Compose** — screens read state with `collectAsStateWithLifecycle()` and drain effects
+inside `repeatOnLifecycle(STARTED)`.
+
+**State design conventions:**
+- UI state classes hold only what the screen renders. Domain models are mapped to per-screen
+  `*UiState` types inside the ViewModel (e.g. `Book.asBookshelfUIState()`).
+- List fields use `kotlinx.collections.immutable` (`ImmutableList`, `persistentListOf()`) so Compose
+  treats them as stable and skips needless recomposition.
+- `@StringRes Int` is carried in effects/state rather than resolved strings, keeping ViewModels free
+  of `Context`.
+
+**Error handling** — repositories and use cases return Kotlin `Result<T>`. Failures are logged with
+Timber using the `T.logTag()` extension
+([`LogExtensions.kt`](../core-platform/src/main/java/com/sriniketh/core_platform/LogExtensions.kt))
+and surfaced to the user as a `ShowMessage` effect. ViewModels branch on `result.isSuccess` /
+`result.isFailure`.
+
+---
+
+## Dependency injection (Hilt)
+
+Hilt wires everything. Conventions:
+
+- One `@Module object`/`abstract class` per layer, installed in `SingletonComponent`.
+- Interface → implementation bindings use `@Binds` (abstract module) or `@Provides` (object module).
+- ViewModels are `@HiltViewModel` and obtained in Compose with `hiltViewModel()`.
+
+| Module file | Binds / provides |
+|-------------|------------------|
+| [`NetworkModule`](../core-network/src/main/java/com/sriniketh/prose/core_network/di/NetworkModule.kt) | `Retrofit`/`BooksApi` (singleton), `BooksRemoteDataSource` |
+| [`DatabaseModule`](../core-db/src/main/java/com/sriniketh/core_db/dagger/DatabaseModule.kt) | `BookDatabase` (singleton), `BookDao`, `HighlightDao` |
+| [`DataModule`](../core-data/src/main/java/com/sriniketh/core_data/di/DataModule.kt) | `BooksRepository`, `HighlightsRepository`, IO `CoroutineDispatcher` |
+| [`PlatformModule`](../core-platform/src/main/java/com/sriniketh/core_platform/dagger/PlatformModule.kt) | `DateTimeSource` |
+| [`AppModule`](../app/src/main/java/com/sriniketh/prose/dagger/AppModule.kt) | `FileSource` → `FileSourceImpl` |
+| [`TextAnalysisModule`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/dagger/TextAnalysisModule.kt) | `TextAnalyzer` → `TextAnalyzerImpl` |
+
+> **Note — split interface/impl.** `FileSource` is *declared* in `core-platform` but *implemented*
+> in `app` ([`FileSourceImpl`](../app/src/main/java/com/sriniketh/prose/files/FileSourceImpl.kt)),
+> because the implementation needs `FileProvider` + the app's `packageName`/authority. `core-data`
+> depends only on the interface. `DateTimeSource`, by contrast, is implemented and bound inside
+> `core-platform`.
+
+The application class [`ProseApplication`](../app/src/main/java/com/sriniketh/prose/ProseApplication.kt)
+is `@HiltAndroidApp` and plants a Timber `DebugTree` in debug builds.
+[`MainActivity`](../app/src/main/java/com/sriniketh/prose/MainActivity.kt) is `@AndroidEntryPoint`.
+
+---
+
+## Navigation
+
+Navigation Compose with **string routes**, defined as a sealed interface in
+[`Navigation.kt`](../app/src/main/java/com/sriniketh/prose/Navigation.kt) and wired in
+[`ProseAppScreen.kt`](../app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt). The start
+destination is `bookshelf`. Arguments are passed as path segments (`view_highlights/{bookId}`).
+
+| Route | Screen | Args |
+|-------|--------|------|
+| `bookshelf` | Bookshelf (start) | — |
+| `search` | Book search | — |
+| `book_info/{bookId}` | Book detail / add-to-shelf | `bookId` |
+| `view_highlights/{bookId}` | Highlights list | `bookId` |
+| `capture_and_crop_image/{bookId}` | Camera + crop | `bookId` |
+| `save_highlight_from_uri/{bookId}/{uri}` | OCR + save new highlight | `bookId`, encoded `uri` |
+| `save_highlight_from_highlight_id/{bookId}/{highlightId}` | Edit existing highlight | `bookId`, `highlightId` |
+
+Notes:
+- The image `uri` is URL-encoded/decoded across the route boundary via
+  [`UriExtensions`](../core-platform/src/main/java/com/sriniketh/core_platform/UriExtensions.kt)
+  (`encodeUri()` / `decodeUri()`).
+- Cross-screen results use `savedStateHandle` on a back-stack entry. Adding a book sets
+  `BOOKSHELF_SHOW_ADDED_MESSAGE` on the bookshelf entry, then pops back to it; the bookshelf
+  ViewModel observes that handle and shows a confirmation snackbar.
+- The whole graph is wrapped in a `SharedTransitionLayout`; the shared scopes are passed down through
+  the `core-design` composition locals to animate book covers between screens.
+
+---
+
+## Cross-cutting conventions
+
+- **No code comments.** The codebase is intentionally comment-free; names and small functions carry
+  the meaning. Match this when contributing.
+- **`Result<T>` everywhere** across the data/domain boundary; never throw across it.
+- **Timber + `logTag()`** for logging; tags are prefixed `PROSE_DEBUG_LOG:`.
+- **Immutable Compose inputs** via `kotlinx.collections.immutable`.
+- **Version catalog only** — reference `libs.*` / `libs.versions.*` / `libs.plugins.*`, never
+  hardcode versions ([`gradle/libs.versions.toml`](../gradle/libs.versions.toml)).
+- **Testing** — ViewModels are unit-tested with Turbine + fake repositories and a
+  `StandardTestDispatcher`; fakes live under each module's `src/test/.../fakes/`. UI tests use the
+  Compose test rule. See `AGENTS.md` for the full testing notes.

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -1,0 +1,231 @@
+# Important Flows
+
+Each flow is traced from the UI down to the data source and back. File paths are given so any step
+can be opened directly. The shared UDF mechanics (StateFlow + effect Channel) are described once in
+[architecture.md](architecture.md#the-udf-contract); this document focuses on what is specific to each
+flow.
+
+---
+
+## 0. App bootstrap
+
+```
+ProseApplication (@HiltAndroidApp, plants Timber in debug)
+  → MainActivity (@AndroidEntryPoint, enableEdgeToEdge, AppTheme)
+    → ProseAppScreen  (SharedTransitionLayout + NavHost, start = "bookshelf")
+```
+
+- [`ProseApplication.kt`](../app/src/main/java/com/sriniketh/prose/ProseApplication.kt) initializes
+  Hilt and logging.
+- [`MainActivity.kt`](../app/src/main/java/com/sriniketh/prose/MainActivity.kt) sets the Compose
+  content inside `AppTheme`.
+- [`ProseAppScreen.kt`](../app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt) builds the
+  `NavHost` and provides the shared-transition composition locals. Start destination is the bookshelf.
+
+---
+
+## 1. Bookshelf — list saved books
+
+**Reads the local DB as a stream; UI updates automatically when books change.**
+
+```
+BookshelfScreen
+  → BookshelfViewModel.init
+      → GetAllSavedBooksUseCase()                       (core-data)
+        → BooksRepository.getAllSavedBooksFromDb(): Flow<Result<List<Book>>>
+          → BookDao.getAllBooks(): Flow<List<BookEntity>>   (Room, core-db)
+      ← entities.map { it.asBook() }  → map to BookUIState (ImmutableList)
+```
+
+Details:
+- The ViewModel collects the DB `Flow` in `init`, so the list is reactive — inserting or deleting a
+  book elsewhere re-emits here. See
+  [`BookshelfViewModel`](../feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfViewModel.kt).
+- A second `init` collector watches `savedStateHandle[BOOKSHELF_SHOW_ADDED_MESSAGE]`; when the
+  add-book flow sets it `true`, a `ShowMessage` effect fires a confirmation snackbar and the flag is
+  reset.
+- DB errors map to `Result.failure` (caught in the repository's `.catch`) → `getallbooks` error
+  snackbar.
+- Tapping a book navigates to `view_highlights/{bookId}`; the FAB navigates to `search`.
+
+---
+
+## 2. Search books — debounced search-as-you-type
+
+**Type a query; results refresh after a short pause, and stale in-flight responses are discarded.**
+
+```
+SearchBookScreen (text field) → SearchBookViewModel.searchForBook(query)
+  → queryFlow (MutableStateFlow)
+      .filter { length > 3 }
+      .debounce(300ms)
+      .distinctUntilChanged()
+      .flatMapLatest { SearchForBookUseCase(query) }     ← cancels the previous search
+        → BooksRepository.searchForBooks
+          → BooksRemoteDataSource.getVolumes(query)  (projection = "lite")
+          ← Volumes.asBookSearchResult()  → BookSearch  → BookUiState list
+```
+
+Details ([`SearchBookViewModel`](../feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookViewModel.kt)):
+- Query and reset are modeled as a `SearchAction` sealed type and `merge`d into one pipeline.
+- `flatMapLatest` is the key to correctness: when a newer query arrives, the in-flight request for the
+  older query is cancelled, so a slow earlier response can never overwrite newer results (the
+  search-as-you-type race condition this design fixes).
+- `resetSearch()` emits `SearchAction.Clear`, restoring the empty state.
+- Tapping a result navigates to `book_info/{bookId}`.
+
+---
+
+## 3. Book info & add to shelf
+
+```
+BookInfoScreen → BookInfoViewModel.getBookDetail(volumeId)
+  → FetchBookInfoUseCase → BooksRepository.fetchBookInfo
+       → BooksRemoteDataSource.getVolume(volumeId)  → Volume.asBook()
+  → IsBookInDbUseCase → BookDao.doesBookExist(bookId)   → canAddToShelf = !isInDb
+
+[user taps "Add to shelf"]
+  → AddBookToShelfUseCase → BooksRepository.insertBookIntoDb
+       → BookDao.insertBook(book.asBookEntity())   (onConflict = IGNORE)
+  → Effect.NavigateToBookshelf
+```
+
+Details ([`BookInfoViewModel`](../feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt)):
+- `canAddToShelf` is computed up front so an already-saved book can't be added twice (DB insert also
+  uses `IGNORE` as a safety net).
+- On success the screen emits `NavigateToBookshelf`. The navigation layer
+  ([`ProseAppScreen.kt`](../app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt)) sets
+  `BOOKSHELF_SHOW_ADDED_MESSAGE = true` on the bookshelf back-stack entry and pops back to it — that
+  is what triggers the bookshelf's "added" snackbar (flow 1).
+
+---
+
+## 4. View highlights
+
+```
+ViewHighlightsScreen → ViewHighlightsViewModel.getHighlights(bookId)
+  → GetAllSavedHighlightsUseCase(bookId)
+      → HighlightsRepository.getAllHighlightsForBookFromDb(bookId): Flow<...>
+        → HighlightDao.getAllHighlightsForBook(bookId): Flow<List<HighlightEntity>>
+  ← sortedBy { savedOnTimestamp } → HighlightUIState list
+```
+
+Actions are dispatched through `processAction(ViewHighlightsAction)`
+([`ViewHighlightsViewModel`](../feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModel.kt)):
+- **Delete** → `DeleteHighlightUseCase` → `HighlightDao.deleteHighlightById(id)`.
+- **Export** → see flow 6.
+- **Camera permission denied** → `permission_denied` snackbar. The screen's camera-permission
+  launcher requests `CAMERA`; on grant it navigates into the capture flow, on deny it dispatches the
+  denied action.
+- Adding a highlight navigates to `capture_and_crop_image/{bookId}`; editing one navigates to
+  `save_highlight_from_highlight_id/{bookId}/{highlightId}`.
+
+---
+
+## 5. Add a highlight — capture → crop → OCR → save
+
+This is the most involved flow and spans two ViewModels and three navigation destinations.
+
+### 5a. Capture & crop
+
+```
+capture_and_crop_image/{bookId}
+  → CaptureAndCropImageScreen + CaptureAndCropImageViewModel
+      imageUri = CreateTempImageFileUseCase()  → FileSource.createNewFile("<uuid>.jpg")
+                 (cacheDir file, exposed via FileProvider; stored in SavedStateHandle)
+      state: CaptureImage → CropImage → ImageCapturedAndCropped
+```
+
+Steps ([`CaptureAndCropImageViewModel`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageViewModel.kt),
+[`CaptureAndCropImageScreen`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreen.kt)):
+1. **CaptureImage** — a `TakePicture` activity-result launcher writes the photo into the temp
+   FileProvider URI. On cancel/failure the screen calls `goBack()`.
+2. **CropImage** — `CropImageScreen` (Cropify) lets the user crop; `onImageCropped()` advances state.
+3. **ImageCapturedAndCropped** — the screen calls `onImageCaptured(uri)`, which URL-encodes the URI
+   and navigates to `save_highlight_from_uri/{bookId}/{encodedUri}`.
+4. **Cleanup** — `onCleared()` deletes the temp file *unless* the flow completed
+   (`ImageCapturedAndCropped`), so abandoned captures don't leak files. The completed file is handed
+   off to the next screen, which deletes it after OCR.
+
+### 5b. OCR & save
+
+```
+save_highlight_from_uri/{bookId}/{uri}
+  → EditAndSaveHighlightScreen(uri) + EditAndSaveHighlightViewModel
+      processImageForHighlightText(uri):
+        → TextAnalyzer.analyzeImage(uri)        (ML Kit on-device Latin OCR)
+        → visionText.text.replace("\n", " ")    → editable highlightText
+        finally → DeleteFileUseCase(uri)         (delete the temp image)
+
+[user edits text, taps save]
+  → saveHighlight(bookId, text)
+      → SaveHighlightUseCase → HighlightsRepository.insertHighlightIntoDb
+          → HighlightDao.insertHighlight(highlight.asHighlightEntity())  (onConflict = REPLACE)
+      timestamp = FormatCurrentDateTimeUseCase(DateTimeSource.now())
+  → Effect.HighlightSaved → goBack to view_highlights/{bookId}
+```
+
+Details:
+- [`TextAnalyzer`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/TextAnalyzer.kt)
+  wraps the callback-based ML Kit recognizer in `suspendCancellableCoroutine` and closes the
+  recognizer on cancellation. OCR runs fully on-device.
+- OCR failure → `image_processing_failure` snackbar; the temp file is deleted in `finally` either way.
+- A new highlight gets a random `UUID` and the current formatted timestamp.
+
+### 5c. Edit an existing highlight
+
+```
+save_highlight_from_highlight_id/{bookId}/{highlightId}
+  → EditAndSaveHighlightViewModel.loadHighlightText(highlightId)
+      → LoadHighlightUseCase → HighlightsRepository.loadHighlightFromDb → HighlightDao.getHighlightById
+  ← prefilled text + screen title switches to "edit"; original savedOnTimestamp is preserved
+[save] → updateHighlight(bookId, text, highlightId)   (same UUID → REPLACE updates the row)
+```
+
+The same [`EditAndSaveHighlightViewModel`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightViewModel.kt)
+serves both new and edit cases. For edits, `savedOnTimestamp` is retained so the original capture time
+is not overwritten, and the existing `highlightId` makes the REPLACE insert an update.
+
+---
+
+## 6. Export & share highlights
+
+```
+ViewHighlights "share" → ViewHighlightsViewModel.processAction(OnExportHighlights(bookId))
+  → ExportHighlightsUseCase(bookId)
+       book       = BooksRepository.getBookByIdFromDb(bookId).getOrThrow()
+       highlights = HighlightsRepository.getAllHighlightsForBookFromDb(bookId).first().getOrThrow()
+       → build HighlightsExport (book info + highlights)
+       → Json { prettyPrint; explicitNulls = false }.encodeToString(...)
+       → FileSource.writeToFile("<title>_export.json", json)   (cacheDir + FileProvider URI)
+  → Effect.ShareHighlights(uri)
+  → screen launches Intent.ACTION_SEND chooser
+       (type application/json, EXTRA_STREAM = uri, FLAG_GRANT_READ_URI_PERMISSION)
+```
+
+Details:
+- [`ExportHighlightsUseCase`](../core-data/src/main/java/com/sriniketh/core_data/usecases/ExportHighlightsUseCase.kt)
+  is one of the few use cases that coordinates **both** repositories. It takes a one-shot snapshot of
+  the highlights `Flow` via `.first()`.
+- The serialized shape is the `*Export` DTO set in
+  [`HighlightsExport.kt`](../core-data/src/main/java/com/sriniketh/core_data/models/HighlightsExport.kt)
+  (kept separate from domain models so the on-disk format is independent of internal types).
+  `explicitNulls = false` omits null fields from the JSON.
+- The file lands in the app cache dir and is shared through the `${applicationId}.fileProvider`
+  declared in [`AndroidManifest.xml`](../app/src/main/AndroidManifest.xml); the share intent grants
+  temporary read permission to the receiving app.
+- Export failure → `export` error snackbar.
+
+---
+
+## Flow ↔ source map (quick index)
+
+| Flow | Screen / ViewModel | Use case(s) | Data source |
+|------|--------------------|-------------|-------------|
+| Bookshelf | `feature-bookshelf` | `GetAllSavedBooksUseCase` | Room `BookDao` (Flow) |
+| Search | `feature-searchbooks` (`SearchBookViewModel`) | `SearchForBookUseCase` | Books API `getVolumes` |
+| Book info / add | `feature-searchbooks` (`BookInfoViewModel`) | `FetchBookInfoUseCase`, `IsBookInDbUseCase`, `AddBookToShelfUseCase` | API `getVolume` + `BookDao` |
+| View highlights | `feature-viewhighlights` | `GetAllSavedHighlightsUseCase`, `DeleteHighlightUseCase` | Room `HighlightDao` (Flow) |
+| Capture / crop | `feature-addhighlight` (`CaptureAndCropImageViewModel`) | `CreateTempImageFileUseCase`, `DeleteFileUseCase` | `FileSource` (cacheDir) |
+| OCR / save | `feature-addhighlight` (`EditAndSaveHighlightViewModel`) | `SaveHighlightUseCase`, `LoadHighlightUseCase`, `FormatCurrentDateTimeUseCase`, `DeleteFileUseCase` | ML Kit + `HighlightDao` |
+| Export / share | `feature-viewhighlights` | `ExportHighlightsUseCase` | both repos + `FileSource` |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,188 @@
+# Modules & Dependency Graph
+
+Prose is split into **7 core modules** and **4 feature modules**, assembled by the `app` module. The
+split enforces the layering described in [architecture.md](architecture.md): features depend on
+`core-data` for everything data-related and never reach a data source directly.
+
+All modules are listed in [`settings.gradle.kts`](../settings.gradle.kts).
+
+## Dependency graph
+
+```mermaid
+graph TD
+    app[":app"]
+
+    fb[":feature-bookshelf"]
+    fs[":feature-searchbooks"]
+    fv[":feature-viewhighlights"]
+    fa[":feature-addhighlight"]
+
+    cdata[":core-data"]
+    cdesign[":core-design"]
+    cplatform[":core-platform"]
+    cnetwork[":core-network"]
+    cdb[":core-db"]
+    cmodels[":core-models"]
+
+    app --> fb & fs & fv & fa
+    app --> cdesign & cplatform
+
+    fb --> cdesign & cdata & cmodels & cplatform
+    fs --> cdesign & cdata & cmodels & cplatform
+    fv --> cdesign & cdata & cmodels
+    fa --> cdesign & cdata & cmodels & cplatform
+
+    cdata --> cnetwork & cdb & cplatform & cmodels
+
+    style cmodels fill:#e8f5e9
+```
+
+`core-network`, `core-db`, `core-design`, and `core-platform` have **no internal module
+dependencies**; `core-models` is a pure Kotlin/JVM library (highlighted above).
+
+Text form (who each module `implementation`-depends on):
+
+```
+app                  → core-design, core-platform, feature-bookshelf,
+                       feature-searchbooks, feature-viewhighlights, feature-addhighlight
+feature-bookshelf    → core-design, core-data, core-models, core-platform
+feature-searchbooks  → core-design, core-data, core-models, core-platform
+feature-viewhighlights → core-design, core-data, core-models   (core-platform is test-only)
+feature-addhighlight → core-design, core-data, core-models, core-platform
+core-data            → core-network, core-db, core-platform, core-models
+core-network         → (none internal)
+core-db              → (none internal)
+core-design          → (none internal)
+core-platform        → (none internal)
+core-models          → (none — pure Kotlin/JVM)
+```
+
+Key invariants:
+- **`core-data` is the only module that depends on `core-network` and `core-db`.** Features cannot
+  see Retrofit or Room types.
+- **`core-models` has no Android dependency**, so domain logic and transformers stay pure and fast to
+  test.
+- **Feature modules do not depend on each other.** Cross-feature navigation is mediated by `app`.
+
+---
+
+## Core modules
+
+### `core-models`
+Pure Kotlin library (`java-library`, `kotlin-jvm`). Domain types only: `Book`, `BookInfo`,
+`Highlight`, `BookSearch`. No DI, no Android.
+
+### `core-platform`
+Android OS abstractions that keep upper layers testable and `Context`-free.
+- [`FileSource`](../core-platform/src/main/java/com/sriniketh/core_platform/FileSource.kt) — create /
+  write / delete files (interface here; impl in `app`).
+- [`DateTimeSource`](../core-platform/src/main/java/com/sriniketh/core_platform/DateTimeSource.kt) —
+  injectable `now()` (impl + Hilt binding here).
+- [`UriExtensions`](../core-platform/src/main/java/com/sriniketh/core_platform/UriExtensions.kt) —
+  `encodeUri()`, `decodeUri()`, `buildHttpsUri()`.
+- [`LogExtensions`](../core-platform/src/main/java/com/sriniketh/core_platform/LogExtensions.kt) —
+  `logTag()`.
+
+### `core-network`
+Retrofit 3 + kotlinx.serialization client for the Google Books API.
+- [`BooksApi`](../core-network/src/main/java/com/sriniketh/prose/core_network/retrofit/BooksApi.kt) —
+  `GET books/v1/volumes` (search) and `GET books/v1/volumes/{id}` (detail).
+- [`BooksRemoteDataSource`](../core-network/src/main/java/com/sriniketh/prose/core_network/BooksRemoteDataSource.kt)
+  — thin wrapper that injects the API key and `projection=lite` for search.
+- [`Volumes`](../core-network/src/main/java/com/sriniketh/prose/core_network/model/Volumes.kt) — DTOs
+  with defaulted/nullable fields; JSON parsed with `ignoreUnknownKeys = true`.
+- **API key:** `BOOKS_API_KEY` is read from `core-network/apikey.properties` into `BuildConfig` at
+  build time. `HttpLoggingInterceptor` logs bodies only in debug.
+
+### `core-db`
+Room database `book-db`.
+- [`BookDatabase`](../core-db/src/main/java/com/sriniketh/core_db/BookDatabase.kt) — version 1,
+  `exportSchema = true` (schemas under `core-db/schemas`).
+- [`BookEntity`](../core-db/src/main/java/com/sriniketh/core_db/entity/BookEntity.kt) and
+  [`HighlightEntity`](../core-db/src/main/java/com/sriniketh/core_db/entity/HighlightEntity.kt). The
+  highlight has a **foreign key to the book with `ON DELETE CASCADE`** and an index on `bookId`, so
+  deleting a book removes its highlights.
+- [`BookDao`](../core-db/src/main/java/com/sriniketh/core_db/dao/BookDao.kt) (insert IGNORE,
+  observe-all `Flow`, exists, get-by-id, delete) and
+  [`HighlightDao`](../core-db/src/main/java/com/sriniketh/core_db/dao/HighlightDao.kt) (insert
+  REPLACE, get-by-id, observe-for-book `Flow`, delete-by-id).
+- [`ListTypeConverter`](../core-db/src/main/java/com/sriniketh/core_db/converters/ListTypeConverter.kt)
+  — stores `List<String>` (authors) as a `|`-delimited string.
+- The database is built with `fallbackToDestructiveMigration(dropAllTables = true)` — schema changes
+  drop and recreate rather than migrate.
+
+### `core-design`
+Compose design system: `AppTheme` (Material 3 + dynamic color), shared components
+(`ProseTopAppBar`, `NavigationBack`, `Placeholder`), typography, animation specs, and the shared
+transition `CompositionLocals`. No internal deps.
+
+### `core-data`
+Repositories, use cases, transformers, and the export DTOs
+([`HighlightsExport`](../core-data/src/main/java/com/sriniketh/core_data/models/HighlightsExport.kt)).
+This is the bridge between data sources and presentation. See
+[architecture.md](architecture.md#repository--domain--core-data) for the type breakdown and
+[flows.md](flows.md) for how each use case is invoked.
+
+**Use cases** (in [`usecases/`](../core-data/src/main/java/com/sriniketh/core_data/usecases)):
+
+| Use case | Backed by | Used in flow |
+|----------|-----------|--------------|
+| `SearchForBookUseCase` | `BooksRepository.searchForBooks` | Search |
+| `FetchBookInfoUseCase` | `BooksRepository.fetchBookInfo` | Book info |
+| `IsBookInDbUseCase` | `BooksRepository.doesBookExistInDb` | Book info |
+| `AddBookToShelfUseCase` | `BooksRepository.insertBookIntoDb` | Add book |
+| `GetAllSavedBooksUseCase` | `BooksRepository.getAllSavedBooksFromDb` | Bookshelf |
+| `DeleteBookUseCase` | `BooksRepository.deleteBookFromDb` | (book removal) |
+| `GetAllSavedHighlightsUseCase` | `HighlightsRepository.getAllHighlightsForBookFromDb` | View highlights |
+| `SaveHighlightUseCase` | `HighlightsRepository.insertHighlightIntoDb` | Save highlight |
+| `LoadHighlightUseCase` | `HighlightsRepository.loadHighlightFromDb` | Edit highlight |
+| `DeleteHighlightUseCase` | `HighlightsRepository.deleteHighlightFromDb` | View highlights |
+| `ExportHighlightsUseCase` | both repos + `FileSource` | Export/share |
+| `CreateTempImageFileUseCase` | `FileSource.createNewFile` | Capture |
+| `DeleteFileUseCase` | `FileSource.deleteFile` | Capture / OCR cleanup |
+| `FormatCurrentDateTimeUseCase` | `DateTimeFormatter` | Save highlight |
+
+---
+
+## Feature modules
+
+Each feature module owns Compose screens + ViewModels + feature DI. ViewModels are `@HiltViewModel`
+and consume `core-data` use cases.
+
+### `feature-bookshelf`
+Home screen. [`BookshelfViewModel`](../feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfViewModel.kt)
+streams saved books from the DB and shows the "book added" confirmation.
+
+### `feature-searchbooks`
+Two screens: search and book detail.
+- [`SearchBookViewModel`](../feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookViewModel.kt)
+  — debounced search-as-you-type with stale-result cancellation.
+- [`BookInfoViewModel`](../feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt)
+  — fetches detail and adds to the shelf.
+
+### `feature-viewhighlights`
+[`ViewHighlightsViewModel`](../feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModel.kt)
+— lists, deletes, and exports/shares a book's highlights; also routes the camera-permission result.
+
+### `feature-addhighlight`
+The most involved feature (camera, crop, OCR, save).
+- [`CaptureAndCropImageViewModel`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageViewModel.kt)
+  — temp-file lifecycle + capture→crop state machine.
+- [`EditAndSaveHighlightViewModel`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightViewModel.kt)
+  — runs OCR, edits, and persists.
+- [`TextAnalyzer`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/TextAnalyzer.kt)
+  — ML Kit on-device Latin recognizer. Depends on `mlkit-text-recognition` and `cropify`.
+
+---
+
+## The `app` module
+Single-Activity host. Owns:
+- [`ProseApplication`](../app/src/main/java/com/sriniketh/prose/ProseApplication.kt) (`@HiltAndroidApp`).
+- [`MainActivity`](../app/src/main/java/com/sriniketh/prose/MainActivity.kt) (`@AndroidEntryPoint`, edge-to-edge).
+- The navigation graph ([`ProseAppScreen.kt`](../app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt),
+  [`Navigation.kt`](../app/src/main/java/com/sriniketh/prose/Navigation.kt)).
+- App-level file plumbing: [`FileSourceImpl`](../app/src/main/java/com/sriniketh/prose/files/FileSourceImpl.kt),
+  [`ProseFileProvider`](../app/src/main/java/com/sriniketh/prose/files/ProseFileProvider.kt), and the
+  `${applicationId}.fileProvider` declaration in
+  [`AndroidManifest.xml`](../app/src/main/AndroidManifest.xml) (paths in `res/xml/file_paths.xml`,
+  rooted at the cache dir). The manifest also declares the ML Kit OCR dependency meta-data.


### PR DESCRIPTION
Adds a documentation set under `docs/` that's both human- and agent-readable, covering the whole app's architecture, modularization, dependency graph, and important flows.

## What's included
- **`docs/README.md`** — index + fast facts (stack, entry points, build).
- **`docs/architecture.md`** — layering, the UDF contract (StateFlow + effect Channel + `Result<T>`), the Hilt DI module map, navigation routes, and cross-cutting conventions.
- **`docs/modules.md`** — per-module breakdown, a Mermaid dependency graph (plus text form), and a use-case → repository → data-source index.
- **`docs/flows.md`** — seven end-to-end flows traced UI→data→UI (bootstrap, bookshelf, search, add book, view highlights, capture→OCR→save, export/share) plus a flow↔source quick-index.

## Notes
- Both audiences: Mermaid/tables render on GitHub; every component is named with its exact file path so agents can jump straight to source.
- Documents the real specifics, e.g. the split `FileSource` interface (declared in `core-platform`, implemented in `app`), `flatMapLatest` cancelling stale searches, `HighlightEntity` cascade-on-delete, the capture temp-file lifecycle, and the `ACTION_SEND` export path.
- Existing `docs/images/` and `docs/superpowers/` are untouched. Docs-only change — no code or build modifications.
🤖 Generated with [Claude Code](https://claude.com/claude-code)