### PR TITLE
chore: remove duplicate Compose test dependency declarations

### DIFF
--- a/feature-addhighlight/build.gradle.kts
+++ b/feature-addhighlight/build.gradle.kts
@@ -75,6 +75,4 @@ dependencies {
 	testImplementation(libs.cashapp.turbine)
 	testImplementation(libs.mockk)
 	androidTestImplementation(libs.android.junit)
-	androidTestImplementation(libs.compose.junit)
-	debugImplementation(libs.compose.test.manifest)
 }

--- a/feature-bookshelf/build.gradle.kts
+++ b/feature-bookshelf/build.gradle.kts
@@ -69,6 +69,4 @@ dependencies {
 	testImplementation(libs.coroutines.test)
 	testImplementation(libs.cashapp.turbine)
 	androidTestImplementation(libs.android.junit)
-	androidTestImplementation(libs.compose.junit)
-	debugImplementation(libs.compose.test.manifest)
 }

--- a/feature-searchbooks/build.gradle.kts
+++ b/feature-searchbooks/build.gradle.kts
@@ -71,6 +71,4 @@ dependencies {
 	testImplementation(libs.coroutines.test)
 	testImplementation(libs.cashapp.turbine)
 	androidTestImplementation(libs.android.junit)
-	androidTestImplementation(libs.compose.junit)
-	debugImplementation(libs.compose.test.manifest)
 }

--- a/feature-viewhighlights/build.gradle.kts
+++ b/feature-viewhighlights/build.gradle.kts
@@ -72,6 +72,4 @@ dependencies {
 	testImplementation(libs.cashapp.turbine)
 	testImplementation(libs.mockk)
 	androidTestImplementation(libs.android.junit)
-	androidTestImplementation(libs.compose.junit)
-	debugImplementation(libs.compose.test.manifest)
 }


### PR DESCRIPTION
Each feature module's `build.gradle.kts` declared two test dependencies twice:

- `androidTestImplementation(libs.compose.junit)`
- `debugImplementation(libs.compose.test.manifest)`

Both already appear in the earlier `androidTest` block (next to `androidTestImplementation(composeBom)`), so the second declaration is redundant. This removes it from all four feature modules, keeping `androidTestImplementation(libs.android.junit)` with the unit-test deps.

Affected: `feature-bookshelf`, `feature-searchbooks`, `feature-viewhighlights`, `feature-addhighlight`.

No behavior change — the same dependencies remain on the same configurations. Verified Gradle configuration still resolves (`./gradlew :feature-bookshelf:help`).
🤖 Generated with [Claude Code](https://claude.com/claude-code)