### PR TITLE
test(feature-searchbooks): mutate Compose state via runOnIdle

### DIFF
--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
@@ -272,7 +272,9 @@ class SearchBookScreenTest {
         composeTestRule.onNodeWithTag("SearchResultsList").performScrollToIndex(19)
         composeTestRule.waitForIdle()
 
-        uiState.value = BookSearchUiState(bookUiStates = (newTopBooks + sharedBooks).toPersistentList())
+        composeTestRule.runOnIdle {
+            uiState.value = BookSearchUiState(bookUiStates = (newTopBooks + sharedBooks).toPersistentList())
+        }
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("New Top Book 0").assertIsDisplayed()


### PR DESCRIPTION
## What
In `SearchBookScreenTest.whenNewResultsArriveThenTheListIsShownFromTheTop`, the test mutated `uiState.value` directly from the test thread. This wraps the mutation in `composeTestRule.runOnIdle { }` so it runs on the UI thread, synchronized with the recomposer. The existing `waitForIdle()` is retained.

## Why
Writing Compose `MutableState` off the UI thread races the recomposer and can cause flaky/non-deterministic test behavior. `runOnIdle` performs the mutation on the UI thread once Compose is idle.

## Verification
Compiled with `./gradlew :feature-searchbooks:compileDebugAndroidTestKotlin` (BUILD SUCCESSFUL). Not run on a device/emulator (instrumented test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)