### PR TITLE
test: use assertDoesNotExist for absent nodes

### DIFF
--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreenTest.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreenTest.kt
@@ -2,7 +2,6 @@ package com.sriniketh.feature_addhighlight
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -79,7 +78,7 @@ class EditAndSaveHighlightScreenTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithTag("AddHighlightLoadingIndicator").assertIsNotDisplayed()
+        composeTestRule.onNodeWithTag("AddHighlightLoadingIndicator").assertDoesNotExist()
     }
 
     @Test

--- a/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
+++ b/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
@@ -1,7 +1,6 @@
 package com.sriniketh.feature_bookshelf
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -124,7 +123,7 @@ class BookshelfScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Go ahead, grab a book!").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("Go ahead, grab a book!").assertDoesNotExist()
     }
 
     @Test
@@ -198,7 +197,7 @@ class BookshelfScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Test Book Title").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("Test Book Title").assertDoesNotExist()
     }
 
     private fun createTestBookUIState(

--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
@@ -1,7 +1,6 @@
 package com.sriniketh.feature_searchbooks
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -193,7 +192,7 @@ class BookInfoScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithContentDescription("Add to shelf").assertIsNotDisplayed()
+        composeTestRule.onNodeWithContentDescription("Add to shelf").assertDoesNotExist()
     }
 
     @Test

--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
@@ -2,7 +2,6 @@ package com.sriniketh.feature_searchbooks
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -244,7 +243,7 @@ class SearchBookScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Test Book Title").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("Test Book Title").assertDoesNotExist()
     }
 
     @Test

--- a/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
+++ b/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
@@ -1,7 +1,6 @@
 package com.sriniketh.feature_viewhighlights
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -53,7 +52,7 @@ class ViewHighlightsScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("No saved highlights").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("No saved highlights").assertDoesNotExist()
     }
 
     @Test
@@ -271,7 +270,7 @@ class ViewHighlightsScreenTest {
         composeTestRule.onNodeWithContentDescription("Options Menu").performClick()
         composeTestRule.onNodeWithText("Delete").performClick()
         composeTestRule.onNodeWithText("Cancel").performClick()
-        composeTestRule.onNodeWithText("Delete highlight").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("Delete highlight").assertDoesNotExist()
     }
 
     private fun createTestHighlightUIState(


### PR DESCRIPTION
## What

Replaces `assertIsNotDisplayed()` with `assertDoesNotExist()` for six UI-test sites where the asserted node is conditionally **not emitted** at all (not merely rendered off-screen/hidden). `assertDoesNotExist()` is the stronger, intent-matching assertion for these cases.

## Sites changed (all verified against the production composable)

- `feature-bookshelf` `BookshelfScreenTest`
  - `whenBooksListIsNotEmptyThenEmptyMessageIsNotDisplayed` — empty message lives in `if (books.isEmpty() && !isLoading)`; the `else if (books.isNotEmpty())` branch runs instead, so it is not emitted.
  - `whenNoBooksArePresentThenNoBookItemsAreDisplayed` — book items come from `items(books)`; none emitted when the list is empty.
- `feature-viewhighlights` `ViewHighlightsScreenTest`
  - `whenHighlightsListIsNotEmptyThenEmptyMessageIsNotDisplayed` — empty message is in `if (highlights.isEmpty())`; `else` branch runs when non-empty.
  - `whenDeleteDialogCancelIsClickedThenDialogIsDismissed` — dialog is gated by `if (showDeleteDialog)`, which becomes false after Cancel, so it is removed from the tree.
- `feature-searchbooks` `SearchBookScreenTest`
  - `whenNoBooksArePresentThenNoBookItemsAreDisplayed` — book items come from `items(bookUiStates)`; none emitted when empty.
- `feature-searchbooks` `BookInfoScreenTest`
  - `whenCannotAddToShelfThenFloatingActionButtonIsHidden` — FAB is in `if (uiState.canAddToShelf)`; not emitted when false.
- `feature-addhighlight` `EditAndSaveHighlightScreenTest`
  - `whenUIStateIsNotLoadingThenProgressIndicatorIsNotDisplayed` — indicator is in `if (uiState.isLoading)`; not emitted when not loading.

No sites were left as `assertIsNotDisplayed` — all candidates were genuinely not-emitted.

## Notes

- `assertDoesNotExist()` is a **member** of `SemanticsNodeInteraction`, not a top-level extension, so it needs no import. The now-unused `assertIsNotDisplayed` import was removed from each file.

## Verification

Compiled per module (no emulator; instrumented tests not run on device):

```
./gradlew :feature-bookshelf:compileDebugAndroidTestKotlin \
  :feature-viewhighlights:compileDebugAndroidTestKotlin \
  :feature-searchbooks:compileDebugAndroidTestKotlin \
  :feature-addhighlight:compileDebugAndroidTestKotlin
```

BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)