### PR TITLE
refactor(test): migrate to v2 createComposeRule

### DIFF
--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreenTest.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreenTest.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme

--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreenTest.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreenTest.kt
@@ -3,7 +3,7 @@ package com.sriniketh.feature_addhighlight
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
+++ b/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
@@ -2,7 +2,7 @@ package com.sriniketh.feature_bookshelf
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
@@ -3,7 +3,7 @@ package com.sriniketh.feature_searchbooks
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
@@ -3,7 +3,7 @@ package com.sriniketh.feature_searchbooks
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
+++ b/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
@@ -2,7 +2,7 @@ package com.sriniketh.feature_viewhighlights
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick


### PR DESCRIPTION
Import-only swap across the 6 Compose UI test classes: `androidx.compose.ui.test.junit4.createComposeRule` → `androidx.compose.ui.test.junit4.v2.createComposeRule`.

## Why
The v1 factory is `@Deprecated(WARNING)` as of `ui-test-junit4` 1.11.0-alpha06. The v2 factory returns the same `ComposeContentTestRule` type, so no test body or structure changes were needed — only the import line in each file.

## Files (6)
- feature-bookshelf/.../BookshelfScreenTest.kt
- feature-viewhighlights/.../ViewHighlightsScreenTest.kt
- feature-searchbooks/.../SearchBookScreenTest.kt
- feature-searchbooks/.../BookInfoScreenTest.kt
- feature-addhighlight/.../CaptureAndCropImageScreenTest.kt
- feature-addhighlight/.../EditAndSaveHighlightScreenTest.kt

## Verification
`compileDebugAndroidTestKotlin` for all 4 feature modules: BUILD SUCCESSFUL.

Deprecation warnings before/after:
- Before (v1 import): 6 `createComposeRule ... is deprecated` warnings (one per file)
- After (v2 import): 0

## Behavioral caveat — must test on device before merge
v2 uses `StandardTestDispatcher` (tasks are queued, not eagerly executed) instead of `UnconfinedTestDispatcher`. Any test that relied on eager dispatch may need explicit synchronization. Instrumented tests were NOT run here (no emulator). RUN THE INSTRUMENTED SUITE ON A DEVICE (project standard: Pixel_8 API 34) BEFORE MERGE.

Recommend merging this PR last to minimize rebasing of test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
