### PR TITLE
chore(test): derive app-bar height from tagged top app bar

### DIFF
--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme
 import kotlinx.collections.immutable.toImmutableList
@@ -52,12 +51,15 @@ class BookInfoScreenTest {
             }
         }
 
-        val collapsedTopAppBarHeight = 64.dp
+        val topAppBarBottom = composeTestRule
+            .onNodeWithTag("BookInfoTopAppBar")
+            .getUnclippedBoundsInRoot()
+            .bottom
         val indicatorTop = composeTestRule
             .onNodeWithTag("BookInfoLoadingIndicator")
             .getUnclippedBoundsInRoot()
             .top
-        assertTrue(indicatorTop >= collapsedTopAppBarHeight)
+        assertTrue(indicatorTop >= topAppBarBottom)
     }
 
     @Test

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -112,6 +112,7 @@ internal fun BookInfo(
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             ProseTopAppBar(
+                modifier = Modifier.testTag("BookInfoTopAppBar"),
                 title = { BookInfoScreenTitle(uiState) },
                 navigationIcon = { NavigationBack(action = goBack) },
                 scrollBehavior = scrollBehavior


### PR DESCRIPTION
This PR now contains **only** the app-bar-height test fix.

The Gradle dependency dedupe that previously rode along on this branch has been removed: PR #106 already owns that change.

### What changed
`BookInfoScreenTest` no longer hardcodes a `64.dp` collapsed top-app-bar height. Instead:
- `BookInfoScreen` tags its `ProseTopAppBar` with `testTag("BookInfoTopAppBar")`.
- The test reads that node's measured bottom via `getUnclippedBoundsInRoot().bottom` and asserts the loading indicator sits below it.

This makes the assertion track the actual rendered app bar rather than a magic number.

### Verification
Compiled both production and androidTest for `feature-searchbooks` (`:feature-searchbooks:compileDebugKotlin` + `:feature-searchbooks:compileDebugAndroidTestKotlin`) — BUILD SUCCESSFUL. Not run on a device/emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)