### PR TITLE
docs: keep docs/ in sync as code changes

### DIFF
--- a/.claude/commands/audit-docs.md
+++ b/.claude/commands/audit-docs.md
@@ -1,8 +1,8 @@
 ---
-description: Reconcile docs/ (architecture, modules, flows) against the actual code and report or fix drift
+description: Reconcile docs/ and AGENTS.md against the actual code and report or fix drift
 ---
 
-Audit the engineering docs under `docs/` against the current state of the repo and report every place they have drifted. Do **not** change code to match the docs — the code is the source of truth; the docs follow it.
+Audit the engineering docs under `docs/` **and the `AGENTS.md` quick reference** against the current state of the repo and report every place they have drifted. Do **not** change code to match the docs — the code is the source of truth; the docs follow it.
 
 Work through these passes in order. For each finding, cite the doc file + line and the contradicting source file.
 
@@ -36,8 +36,21 @@ For each of the documented flows (bootstrap, bookshelf, search, add book, view h
 
 Verify min/target/compile SDK, JVM toolchain, and key-library claims against `gradle/libs.versions.toml` and the module `build.gradle.kts` files.
 
+## 6. Agent quick reference — `AGENTS.md`
+
+`AGENTS.md` carries a condensed "Architecture Overview" that duplicates parts of `docs/`, so it drifts the same way (it has already gone stale on the JSON library once). Cross-check its concrete claims against the code, not against `docs/`:
+
+- **Module Structure** list — every module present and described correctly (responsibilities, named entities/types).
+- **Key Libraries** — the named stack (networking + JSON converter, image loading, cropping, logging, OCR) matches `gradle/libs.versions.toml`. The JSON library is the known drift point: confirm it against the actual `core-network` imports and converter dependency, not the prose.
+- **Dependency Injection** — the named `@Module` classes exist and the stated DI-package convention matches reality.
+- **Navigation** — the `Navigation.kt` path and any example route still hold.
+- **Testing Patterns** — the named test libraries and dispatcher pattern are still what the suites use.
+- **Build Commands / API Key Setup** — the Gradle invocations and `core-network/apikey.properties` key name are current.
+
+Flag any claim that contradicts the code. Keep this section a true *summary* — if a fix would mean adding deep detail, correct the fact tersely and note that the depth belongs in `docs/`.
+
 ## Output
 
 Produce a prioritized list: **(P1)** dead/moved paths, **(P2)** missing or wrong module/route/flow structure, **(P3)** stale fast facts or wording. For each, give the exact doc edit needed.
 
-If invoked with `--fix`, apply the edits to the `docs/` files after presenting the list. Otherwise report only and let the user decide. Never invent paths — every corrected path must point at a file you confirmed exists.
+If invoked with `--fix`, apply the edits to the `docs/` files and `AGENTS.md` after presenting the list. Otherwise report only and let the user decide. Never invent paths — every corrected path must point at a file you confirmed exists.

--- a/.claude/commands/audit-docs.md
+++ b/.claude/commands/audit-docs.md
@@ -38,7 +38,7 @@ Verify min/target/compile SDK, JVM toolchain, and key-library claims against `gr
 
 ## 6. Agent quick reference — `AGENTS.md`
 
-`AGENTS.md` carries a condensed "Architecture Overview" that duplicates parts of `docs/`, so it drifts the same way (it has already gone stale on the JSON library once). Cross-check its concrete claims against the code, not against `docs/`:
+`AGENTS.md` carries a condensed "Architecture Overview" that duplicates parts of `docs/`, so it drifts the same way. Cross-check its concrete claims against the code, not against `docs/`:
 
 - **Module Structure** list — every module present and described correctly (responsibilities, named entities/types).
 - **Key Libraries** — the named stack (networking + JSON converter, image loading, cropping, logging, OCR) matches `gradle/libs.versions.toml`. The JSON library is the known drift point: confirm it against the actual `core-network` imports and converter dependency, not the prose.

--- a/.claude/commands/audit-docs.md
+++ b/.claude/commands/audit-docs.md
@@ -1,0 +1,43 @@
+---
+description: Reconcile docs/ (architecture, modules, flows) against the actual code and report or fix drift
+---
+
+Audit the engineering docs under `docs/` against the current state of the repo and report every place they have drifted. Do **not** change code to match the docs — the code is the source of truth; the docs follow it.
+
+Work through these passes in order. For each finding, cite the doc file + line and the contradicting source file.
+
+## 1. Path references (deterministic — do this first)
+
+Every component in the docs is named by a concrete path. Extract every file path referenced in `docs/README.md`, `docs/architecture.md`, `docs/modules.md`, and `docs/flows.md` — both markdown links (`[`Foo`](../path/Foo.kt)`) and inline code paths — and verify each target exists. Run:
+
+```bash
+grep -oE '\(\.\./[^)]+\)|`[a-zA-Z0-9_./-]+\.(kt|kts|toml|properties)`' docs/*.md
+```
+
+then resolve each path (links are relative to `docs/`, so `../` is repo root) and flag any that no longer exist or have moved. Dead paths are the highest-priority finding.
+
+## 2. Module graph — `docs/modules.md`
+
+- List actual Gradle modules from `settings.gradle.kts`. Compare against the per-module entries and the Mermaid + text dependency graph. Flag added/removed/renamed modules and any module missing an entry.
+- For each module, read its `build.gradle.kts` `dependencies {}` block and verify the documented inter-module edges (`implementation(project(":core-data"))` etc.) match the graph. A feature module depending on anything other than `core-data` for data is a doc-worthy violation of the stated rule.
+- Verify the use-case → repository → data-source index lists every `*UseCase` and `*Repository` actually present in `core-data`.
+
+## 3. Architecture contract — `docs/architecture.md`
+
+- Hilt DI map: confirm each documented `@Module` still exists with the stated bindings (`di/` packages across modules).
+- Navigation routes: compare the documented routes against `app/.../Navigation.kt` and `ProseAppScreen.kt`. Flag renamed/added/removed routes and changed arguments.
+- UDF/`Result<T>` contract, effect `Channel`, and cross-cutting conventions: spot-check one ViewModel per feature to confirm the described shape still holds.
+
+## 4. Flows — `docs/flows.md`
+
+For each of the documented flows (bootstrap, bookshelf, search, add book, view highlights, capture→OCR→save, export/share), trace the described UI→data→UI path against the real code. Flag any step where the named class/function no longer exists or the path through the layers has changed (e.g. a UseCase inserted/removed, a different repository call).
+
+## 5. Fast facts — `docs/README.md`
+
+Verify min/target/compile SDK, JVM toolchain, and key-library claims against `gradle/libs.versions.toml` and the module `build.gradle.kts` files.
+
+## Output
+
+Produce a prioritized list: **(P1)** dead/moved paths, **(P2)** missing or wrong module/route/flow structure, **(P3)** stale fast facts or wording. For each, give the exact doc edit needed.
+
+If invoked with `--fix`, apply the edits to the `docs/` files after presenting the list. Otherwise report only and let the user decide. Never invent paths — every corrected path must point at a file you confirmed exists.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Prose is a multi-module Android app for capturing book highlights from physical 
 ### Module Structure
 
 **Core Modules:**
-- `core-network` - Retrofit API client for Google Books API (Moshi for JSON)
+- `core-network` - Retrofit API client for Google Books API (kotlinx.serialization for JSON)
 - `core-db` - Room database with `BookEntity` and `HighlightEntity`
 - `core-data` - Repositories and UseCases that combine network/db operations
 - `core-models` - Domain models (`Book`, `Highlight`, `BookSearch`) — pure Kotlin, no Android deps
@@ -83,7 +83,7 @@ Network/Database → Repository → UseCase → ViewModel → Compose UI
 
 ### Dependency Injection
 
-Hilt is used throughout. Each module has a `di/` package with `@Module` classes:
+Hilt is used throughout. Each module has a DI package (`di/` or `dagger/`) with `@Module` classes:
 - `NetworkModule` provides Retrofit/OkHttp instances
 - `DatabaseModule` provides Room database and DAOs
 - `DataModule` binds repository implementations
@@ -95,7 +95,7 @@ Navigation Compose with routes defined in `app/src/main/java/com/sriniketh/prose
 ### Key Libraries
 
 - **Compose BOM** for UI with Material 3 + DynamicColors
-- **Retrofit 3 + Moshi** for networking
+- **Retrofit 3 + kotlinx.serialization** for networking
 - **Room** for local persistence
 - **Coil** for image loading
 - **Cropify** for image cropping

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,15 @@ In-depth engineering docs live under [`docs/`](docs/) and are written to be both
 
 Consult these before making non-trivial changes; the summary below is a quick reference.
 
+**Keep them in sync.** These docs name exact file paths, the module graph, and concrete flows, so they drift the moment code moves. When a change does any of the following, update the relevant `docs/` file in the same change set:
+
+- Adds, removes, or renames a Gradle module → `docs/modules.md` (per-module entry + dependency graph) and the fast facts in `docs/README.md`.
+- Alters Hilt wiring, the UDF/`Result<T>` contract, navigation routes, or a cross-cutting convention → `docs/architecture.md`.
+- Changes a user-facing flow or the UI→data→UI path of one → `docs/flows.md`.
+- Moves or renames any file referenced by path in a doc → fix the path everywhere it appears.
+
+If a change touches none of the above (e.g. an internal refactor with no structural or flow impact), the docs need no edit. When unsure, run the audit described in `.claude/commands/audit-docs.md`.
+
 ## Build Commands
 
 ```bash


### PR DESCRIPTION
Follow-up to #105, which added the `docs/` reference. Those docs name exact file paths, the module graph, and concrete flows, so they drift the moment code moves. This adds two mechanisms to keep them current.

## Changes
- **AGENTS.md** — upgrades the existing "consult these docs" line into an explicit keep-in-sync contract: which doc to update for module add/remove/rename, Hilt/UDF/navigation changes, flow changes, and file moves/renames. Includes a carve-out so pure internal refactors with no structural or flow impact need no doc edit (avoids noise). Since nearly all changes here land through coding agents, this is the layer that keeps the docs' semantics current.
- **`.claude/commands/audit-docs.md`** — on-demand `/audit-docs` command. Five passes: deterministic path-existence check, module graph vs `settings.gradle.kts`/`build.gradle.kts`, architecture contract (Hilt map, nav routes, UDF), the seven flows traced against code, and fast facts vs `libs.versions.toml`. Reports a P1/P2/P3 list by default; `--fix` applies the edits. Code is treated as source of truth — the command never edits code to match docs and never invents paths.

## Notes
- Docs/tooling only — no code or build changes.
- Verified the docs are currently in sync (62 path references resolve).
- CI guards (a path-existence check job, a co-change reminder) were considered but deliberately left out per scope; easy to add later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)