### PR TITLE
test: find interactive nodes by testTag instead of text

### DIFF
--- a/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
+++ b/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
@@ -180,7 +180,7 @@ class BookshelfScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Test Book").performClick()
+        composeTestRule.onNodeWithTag("BookItem_test-book-id").performClick()
         assertTrue(calledBookId == bookId)
     }
 

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
@@ -158,6 +158,7 @@ internal fun Bookshelf(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(12.dp)
+                            .testTag("BookItem_${bookUIState.id}")
                             .clickable { goToHighlight(bookUIState.id) },
                         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
                     ) {

--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
@@ -78,7 +78,7 @@ class SearchBookScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Search for a book").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
         composeTestRule.onNodeWithTag("SearchBookLoadingIndicator").assertIsDisplayed()
     }
 
@@ -98,7 +98,7 @@ class SearchBookScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Search for a book").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
         composeTestRule.onNodeWithText("Test Book Title").assertIsDisplayed()
     }
 
@@ -118,7 +118,7 @@ class SearchBookScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Search for a book").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
         composeTestRule.onNodeWithText("Author One, Author Two").assertIsDisplayed()
     }
 
@@ -138,7 +138,7 @@ class SearchBookScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Search for a book").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
         composeTestRule.onNodeWithText("Test Subtitle").assertIsDisplayed()
     }
 
@@ -160,8 +160,8 @@ class SearchBookScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Search for a book").performClick()
-        composeTestRule.onNodeWithText("Test Book").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
+        composeTestRule.onNodeWithTag("SearchResultItem_test-book-id").performClick()
         assertEquals(bookId, navigatedBookId)
     }
 
@@ -180,7 +180,7 @@ class SearchBookScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Search for a book").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
         composeTestRule.onNodeWithContentDescription("Close icon").assertIsDisplayed()
     }
 
@@ -200,8 +200,8 @@ class SearchBookScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Search for a book").performClick()
-        composeTestRule.onNodeWithText("Search for a book").performTextInput("test query")
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performTextInput("test query")
 
         assertEquals("test query", searchQuery)
     }
@@ -222,8 +222,8 @@ class SearchBookScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Search for a book").performClick()
-        composeTestRule.onNodeWithText("Search for a book").performTextInput("test")
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performTextInput("test")
         composeTestRule.onNodeWithContentDescription("Close icon").performClick()
 
         assertTrue(resetSearchCalled)
@@ -268,7 +268,7 @@ class SearchBookScreenTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Search for a book").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
         composeTestRule.onNodeWithTag("SearchResultsList").performScrollToIndex(19)
         composeTestRule.waitForIdle()
 

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
@@ -130,6 +130,7 @@ internal fun SearchBook(
                 .fillMaxWidth(),
             inputField = {
                 SearchBarDefaults.InputField(
+                    modifier = Modifier.testTag("SearchBookTextField"),
                     query = text,
                     onQueryChange = {
                         text = it
@@ -197,6 +198,7 @@ internal fun SearchBook(
                             .padding(12.dp)
                             .align(Alignment.Start)
                             .fillMaxWidth()
+                            .testTag("SearchResultItem_${item.id}")
                             .clickable { navigateToBookInfo(item.id) }
                     ) {
                         val uri = remember(item.thumbnailLink) {

--- a/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
+++ b/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -204,7 +205,7 @@ class ViewHighlightsScreenTest {
         }
 
         composeTestRule.onNodeWithContentDescription("Options Menu").performClick()
-        composeTestRule.onNodeWithText("Edit").performClick()
+        composeTestRule.onNodeWithTag("HighlightMenuItemEdit").performClick()
         assertTrue(actionTriggered is ViewHighlightsAction.OnEditHighlight)
         assertEquals(highlightId, (actionTriggered as ViewHighlightsAction.OnEditHighlight).highlightId)
     }
@@ -225,7 +226,7 @@ class ViewHighlightsScreenTest {
         }
 
         composeTestRule.onNodeWithContentDescription("Options Menu").performClick()
-        composeTestRule.onNodeWithText("Delete").performClick()
+        composeTestRule.onNodeWithTag("HighlightMenuItemDelete").performClick()
         composeTestRule.onNodeWithText("Delete highlight").assertIsDisplayed()
         composeTestRule.onNodeWithText("Are you sure you want to remove this highlight from your device?").assertIsDisplayed()
     }
@@ -247,8 +248,8 @@ class ViewHighlightsScreenTest {
         }
 
         composeTestRule.onNodeWithContentDescription("Options Menu").performClick()
-        composeTestRule.onNodeWithText("Delete").performClick()
-        composeTestRule.onNodeWithText("Delete").performClick()
+        composeTestRule.onNodeWithTag("HighlightMenuItemDelete").performClick()
+        composeTestRule.onNodeWithTag("DeleteHighlightConfirmButton").performClick()
         assertTrue(actionTriggered is ViewHighlightsAction.OnDeleteHighlight)
         assertEquals(highlightId, (actionTriggered as ViewHighlightsAction.OnDeleteHighlight).highlightId)
     }
@@ -269,8 +270,8 @@ class ViewHighlightsScreenTest {
         }
 
         composeTestRule.onNodeWithContentDescription("Options Menu").performClick()
-        composeTestRule.onNodeWithText("Delete").performClick()
-        composeTestRule.onNodeWithText("Cancel").performClick()
+        composeTestRule.onNodeWithTag("HighlightMenuItemDelete").performClick()
+        composeTestRule.onNodeWithTag("DeleteHighlightCancelButton").performClick()
         composeTestRule.onNodeWithText("Delete highlight").assertIsNotDisplayed()
     }
 

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.platform.toClipEntry
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -298,6 +299,7 @@ internal fun ViewHighlights(
                                 expanded = expandDropDownMenu,
                                 onDismissRequest = { expandDropDownMenu = false }) {
                                 DropdownMenuItem(
+                                    modifier = Modifier.testTag("HighlightMenuItemCopy"),
                                     text = {
                                         Text(
                                             text = stringResource(id = R.string.highlight_menu_item_copy),
@@ -312,6 +314,7 @@ internal fun ViewHighlights(
                                     }
                                 )
                                 DropdownMenuItem(
+                                    modifier = Modifier.testTag("HighlightMenuItemEdit"),
                                     text = {
                                         Text(
                                             text = stringResource(id = R.string.highlight_menu_item_edit),
@@ -324,6 +327,7 @@ internal fun ViewHighlights(
                                     }
                                 )
                                 DropdownMenuItem(
+                                    modifier = Modifier.testTag("HighlightMenuItemDelete"),
                                     text = {
                                         Text(
                                             text = stringResource(id = R.string.highlight_menu_item_delete),
@@ -366,6 +370,7 @@ private fun DeleteHighlightAlertDialog(
         },
         confirmButton = {
             ElevatedButton(
+                modifier = Modifier.testTag("DeleteHighlightConfirmButton"),
                 onClick = {
                     onConfirm()
                     hideDeleteDialog()
@@ -381,7 +386,10 @@ private fun DeleteHighlightAlertDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = { hideDeleteDialog() }) {
+            TextButton(
+                modifier = Modifier.testTag("DeleteHighlightCancelButton"),
+                onClick = { hideDeleteDialog() }
+            ) {
                 Text(
                     text = stringResource(id = R.string.delete_dialog_negative_button_label),
                     style = MaterialTheme.typography.labelLarge,


### PR DESCRIPTION
## What

Reduces Compose-test finder fragility by adding production \`testTag\`s to interactive/ambiguous elements and retargeting the click/text-input interactions in the tests to those tags. Display-text assertions are left as text finders.

## Production tags added

feature-viewhighlights (\`ViewHighlightsScreen.kt\`):
- \`HighlightMenuItemCopy\`, \`HighlightMenuItemEdit\`, \`HighlightMenuItemDelete\` on the overflow \`DropdownMenuItem\`s
- \`DeleteHighlightConfirmButton\` (confirm \`ElevatedButton\`), \`DeleteHighlightCancelButton\` (dismiss \`TextButton\`) in the delete dialog

feature-searchbooks (\`SearchBookScreen.kt\`):
- \`SearchBookTextField\` on the \`SearchBarDefaults.InputField\`
- \`SearchResultItem_\${id}\` on each search-result \`Row\`

feature-bookshelf (\`BookshelfScreen.kt\`):
- \`BookItem_\${id}\` on each book \`Card\`

## Test interactions retargeted

- ViewHighlightsScreenTest: edit/delete menu clicks, delete-dialog confirm/cancel clicks now use tags.
- SearchBookScreenTest: search field click-to-expand and \`performTextInput\` now use \`SearchBookTextField\`; result-row click uses \`SearchResultItem_test-book-id\`.
- BookshelfScreenTest: row click uses \`BookItem_test-book-id\`.

## Delete ambiguity fix

\`whenDeleteDialogConfirmIsClickedThenOnDeleteIsCalled\` previously clicked \`onNodeWithText("Delete")\` twice (menu item then dialog confirm). It now clicks \`HighlightMenuItemDelete\` then \`DeleteHighlightConfirmButton\`, removing the menu-vs-dialog text ambiguity.

## Left as-is

All display-text assertions (titles, authors, subtitle, placeholder text, dialog title/message, empty-state copy, menu-item visibility) remain text finders.

## Verification

Compiled production + androidTest for all three modules (\`compileDebugKotlin\` + \`compileDebugAndroidTestKotlin\`): BUILD SUCCESSFUL. Not run on device (no emulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)