### PR TITLE
docs: tighten /audit-docs per writing-skills audit

### DIFF
--- a/.claude/commands/audit-docs.md
+++ b/.claude/commands/audit-docs.md
@@ -1,5 +1,5 @@
 ---
-description: Reconcile docs/ and AGENTS.md against the actual code and report or fix drift
+description: Use when docs/ or AGENTS.md may have drifted from the code (after refactors, renames, module or dependency changes) to reconcile them against the source and report or fix drift
 ---
 
 Audit the engineering docs under `docs/` **and the `AGENTS.md` quick reference** against the current state of the repo and report every place they have drifted. Do **not** change code to match the docs — the code is the source of truth; the docs follow it.
@@ -16,6 +16,8 @@ grep -oE '\(\.\./[^)]+\)|`[a-zA-Z0-9_./-]+\.(kt|kts|toml|properties)`' docs/*.md
 
 then resolve each path (links are relative to `docs/`, so `../` is repo root) and flag any that no longer exist or have moved. Dead paths are the highest-priority finding.
 
+The grep over-matches; do not report a hit as missing until you confirm it. Two forms are not literal paths: an elided segment like `app/.../MainActivity.kt` (the `.../` is an abbreviation — resolve it to the real file before judging) and a bare filename like `` `Navigation.kt` `` used inline (illustrative, not a link). Only a fully-spelled path that resolves nowhere is a dead path.
+
 ## 2. Module graph — `docs/modules.md`
 
 - List actual Gradle modules from `settings.gradle.kts`. Compare against the per-module entries and the Mermaid + text dependency graph. Flag added/removed/renamed modules and any module missing an entry.
@@ -24,7 +26,7 @@ then resolve each path (links are relative to `docs/`, so `../` is repo root) an
 
 ## 3. Architecture contract — `docs/architecture.md`
 
-- Hilt DI map: confirm each documented `@Module` still exists with the stated bindings (`di/` packages across modules).
+- Hilt DI map: confirm each documented `@Module` still exists with the stated bindings. Modules keep them in `di/` or `dagger/` packages — search both, not just `di/`.
 - Navigation routes: compare the documented routes against `app/.../Navigation.kt` and `ProseAppScreen.kt`. Flag renamed/added/removed routes and changed arguments.
 - UDF/`Result<T>` contract, effect `Channel`, and cross-cutting conventions: spot-check one ViewModel per feature to confirm the described shape still holds.
 


### PR DESCRIPTION
Follow-up to #111. Audited the `/audit-docs` command against the `superpowers:writing-skills` guidance and fixed three issues in `.claude/commands/audit-docs.md`.

## Findings & fixes
- **Pass 3 bug** — it told the agent to look for `@Module` bindings in "`di/` packages across modules," but modules split between `di/` and `dagger/`. As written, the command reproduced the exact DI-package drift it exists to catch (it would miss `DatabaseModule`, `PlatformModule`, `AppModule`, `TextAnalysisModule`). Now searches both.
- **Pass 1 gap (empirically confirmed)** — the path-extraction grep over-matches: elided forms like `app/.../MainActivity.kt` and bare inline filenames like `Navigation.kt` are not dead paths. Running the grep flagged 8 false "missing" hits, all real files. Added a note to resolve abbreviations and ignore bare filenames before flagging, so the agent doesn't report false P1s.
- **Description (skill discovery)** — switched from a what-it-does line to a trigger-oriented "Use when…" description, per the writing-skills SDO guidance, since the command is also surfaced as an auto-selectable skill.

Reference/technique skill, so no rationalization tables apply. Full subagent pressure-testing was not run (appropriate for a reference command); the pass-1 fix comes from a real gap-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)