### PR TITLE
chore: bump compileSdkVersion to 37

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-compileSdkVersion = "36"
+compileSdkVersion = "37"
 minSdkVersion = "26"
 targetSdkVersion = "35"
 jvmToolchainVersion = "17"


### PR DESCRIPTION
## Summary

- Bumps `compileSdkVersion` from 36 → 37 in `gradle/libs.versions.toml`
- Required by `androidx.core:core-ktx 1.19.0` (PR #125) and `material3 1.5.0-alpha22` (PR #116), both of which transitively require compileSdk ≥ 37
- Renovate owns its PR branches and force-pushes over manual commits, so this needs to land on `main` first; Renovate PRs will rebase automatically

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, re-queue PR #125 and PR #116 — both should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)