### PR TITLE
Fix MissingFieldException on zero-result Google Books searches

### DIFF
--- a/core-network/src/main/java/com/sriniketh/prose/core_network/model/Volumes.kt
+++ b/core-network/src/main/java/com/sriniketh/prose/core_network/model/Volumes.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class Volumes(
-    val items: List<Volume>
+    val items: List<Volume> = emptyList()
 )
 
 @Serializable

--- a/core-network/src/test/java/com/sriniketh/prose/core_network/di/BooksApiJsonTest.kt
+++ b/core-network/src/test/java/com/sriniketh/prose/core_network/di/BooksApiJsonTest.kt
@@ -128,4 +128,18 @@ class BooksApiJsonTest {
 
         assertEquals(null, volumes.items[0].volumeInfo.imageLinks?.thumbnail)
     }
+
+    @Test
+    fun `decodes volumes to empty list when items is omitted for zero results`() {
+        val payload = """
+            {
+              "kind": "books#volumes",
+              "totalItems": 0
+            }
+        """.trimIndent()
+
+        val volumes = booksApiJson.decodeFromString<Volumes>(payload)
+
+        assertEquals(emptyList<Volumes>(), volumes.items)
+    }
 }


### PR DESCRIPTION
## Summary
- `Volumes.items` had no default, but Google Books omits the `items` field entirely when `totalItems == 0` (a valid, common empty-search-result response)
- `ignoreUnknownKeys` only tolerates extra keys, not missing ones, so kotlinx.serialization threw `MissingFieldException` and users saw a generic search error instead of a proper empty-results state
- Fix: default `items` to `emptyList()`, matching every other field in this DTO

## Test plan
- [x] Added `decodes volumes to empty list when items is omitted for zero results` to `BooksApiJsonTest`, decoding `{"kind":"books#volumes","totalItems":0}`; confirmed it fails with `MissingFieldException` before the fix and passes after
- [x] `./gradlew :core-network:test` green