### PR TITLE
Fix stale highlight text from unkeyed remember

### DIFF
--- a/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
+++ b/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
@@ -1,5 +1,8 @@
 package com.sriniketh.feature_viewhighlights
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -272,6 +275,39 @@ class ViewHighlightsScreenTest {
         composeTestRule.onNodeWithTag("HighlightMenuItemDelete").performClick()
         composeTestRule.onNodeWithTag("DeleteHighlightCancelButton").performClick()
         composeTestRule.onNodeWithText("Delete highlight").assertDoesNotExist()
+    }
+
+    @Test
+    fun whenHighlightTextIsEditedThenNewTextIsDisplayedImmediately() {
+        val highlightId = "test-id"
+        var uiState by mutableStateOf(
+            ViewHighlightsUIState(
+                highlights = persistentListOf(
+                    createTestHighlightUIState(id = highlightId, text = "Original highlight text")
+                )
+            )
+        )
+
+        composeTestRule.setContent {
+            AppTheme {
+                ViewHighlights(
+                    uiState = uiState,
+                    bookId = "test-book-id",
+                    onAction = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Original highlight text").assertIsDisplayed()
+
+        uiState = ViewHighlightsUIState(
+            highlights = persistentListOf(
+                createTestHighlightUIState(id = highlightId, text = "Edited highlight text")
+            )
+        )
+
+        composeTestRule.onNodeWithText("Edited highlight text").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Original highlight text").assertDoesNotExist()
     }
 
     private fun createTestHighlightUIState(

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -246,12 +246,11 @@ internal fun ViewHighlights(
                     val clipboardData = remember(clipboardLabel, highlightUiState.text) {
                         ClipData.newPlainText(clipboardLabel, highlightUiState.text)
                     }
-                    var highlightText by remember {
-                        if (shortenHighlightText) {
-                            mutableStateOf(highlightUiState.text.take(250) + " ...")
-                        } else {
-                            mutableStateOf(highlightUiState.text)
-                        }
+                    var isHighlightTextExpanded by remember { mutableStateOf(false) }
+                    val highlightText = if (shortenHighlightText && !isHighlightTextExpanded) {
+                        highlightUiState.text.take(250) + " ..."
+                    } else {
+                        highlightUiState.text
                     }
 
                     Row(
@@ -261,7 +260,7 @@ internal fun ViewHighlights(
                             .animateContentSize()
                             .clickable {
                                 if (shortenHighlightText) {
-                                    highlightText = highlightUiState.text
+                                    isHighlightTextExpanded = true
                                 }
                             },
                         horizontalArrangement = Arrangement.SpaceBetween


### PR DESCRIPTION
## Summary
- `ViewHighlightsScreen.kt`'s per-item `highlightText` was held in an unkeyed `remember`, so editing a highlight's text left the stale value on screen until the list item scrolled out of and back into composition.
- Replaced it with `isHighlightTextExpanded: Boolean`, matching the existing `expandDropDownMenu` pattern in the same item scope, and derive the displayed text (truncated vs full) from the current `highlightUiState.text` on every composition. No `remember` needed for the text itself.
- Scope limited to lines 249-255/262-266; left the unrelated `LaunchedEffect(bookId)` block (lines 81-83) alone, which is being changed in a separate PR.

## Test plan
- [x] Added `whenHighlightTextIsEditedThenNewTextIsDisplayedImmediately` to `ViewHighlightsScreenTest.kt`; confirmed it fails against the old code (stale text stays displayed) and passes with the fix.
- [x] `./gradlew :feature-viewhighlights:testDebugUnitTest` — pass.
- [x] `./gradlew :feature-viewhighlights:connectedDebugAndroidTest` on Pixel_8 API 34 emulator — all 14 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)