### PR TITLE
Fix rotation/process-death bugs from LaunchedEffect-driven ViewModel loads

### DIFF
--- a/app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt
+++ b/app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt
@@ -158,11 +158,9 @@ internal fun ProseAppScreen(
                     arguments = listOf(navArgument(Screen.BOOKINFO.argBookId) {
                         type = NavType.StringType
                     })
-                ) { backStackEntry ->
+                ) {
                     BookInfoScreen(
                         modifier = modifier,
-                        bookId = backStackEntry.arguments?.getString(Screen.BOOKINFO.argBookId)
-                            .orEmpty(),
                         goBack = { navController.navigateUp() },
                         onBookAddedToShelf = {
                             navController.getBackStackEntry(Screen.BOOKSHELF.route)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,6 +112,23 @@ uses a sealed `ViewHighlightsAction` dispatched through a single `processAction(
 **Collection in Compose** — screens read state with `collectAsStateWithLifecycle()` and drain effects
 inside `repeatOnLifecycle(STARTED)`.
 
+**Nav args and one-shot loads** — ViewModels that need a nav arg (`bookId`, `uri`, `highlightId`)
+inject `SavedStateHandle` (populated automatically by `hiltViewModel()` from the current
+`NavBackStackEntry`) and read the arg in `init` or a property initializer, never via a value pushed
+in from the composable. The initial load itself happens once, either directly in `init`
+(`ViewHighlightsViewModel`, `BookInfoViewModel`) or behind a "started" boolean guard on the
+triggering function (`EditAndSaveHighlightViewModel.processImageForHighlightText` /
+`loadHighlightText`) so a second call is a no-op. Screens must **not** re-trigger the load from a
+`LaunchedEffect` keyed on the nav arg — the arg doesn't change across a configuration change, but the
+`LaunchedEffect` still re-fires because the Compose tree (and its `remember`/`LaunchedEffect` slot
+table) is recreated on rotation even though the same `ViewModel` instance survives; an
+externally-triggered load has no way to know it already ran. `CaptureAndCropImageViewModel` is the
+reference implementation for reading a value out of `SavedStateHandle`
+(`savedStateHandle.get<Uri>("imageUri")`); it also persists which phase (capture / crop / done) it's
+in, so process death mid-crop resumes the crop step instead of relaunching the camera.
+`EditAndSaveHighlightViewModel` persists the in-progress highlight text the same way so an edit
+survives process death even after the source image file has been deleted.
+
 **State design conventions:**
 - UI state classes hold only what the screen renders. Domain models are mapped to per-screen
   `*UiState` types inside the ViewModel (e.g. `Book.asBookshelfUIState()`).

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -79,7 +79,8 @@ Details ([`SearchBookViewModel`](../feature-searchbooks/src/main/java/com/srinik
 ## 3. Book info & add to shelf
 
 ```
-BookInfoScreen → BookInfoViewModel.getBookDetail(volumeId)
+BookInfoScreen → hiltViewModel() populates BookInfoViewModel's SavedStateHandle with bookId
+  → init reads bookId, calls getBookDetail(bookId) once
   → FetchBookInfoUseCase → BooksRepository.fetchBookInfo
        → BooksRemoteDataSource.getVolume(volumeId)  → Volume.asBook()
   → IsBookInDbUseCase → BookDao.doesBookExist(bookId)   → canAddToShelf = !isInDb
@@ -103,8 +104,8 @@ Details ([`BookInfoViewModel`](../feature-searchbooks/src/main/java/com/sriniket
 ## 4. View highlights
 
 ```
-ViewHighlightsScreen → ViewHighlightsViewModel.getHighlights(bookId)
-  → GetAllSavedHighlightsUseCase(bookId)
+ViewHighlightsScreen → hiltViewModel() populates ViewHighlightsViewModel's SavedStateHandle with bookId
+  → init collects GetAllSavedHighlightsUseCase(bookId) once, for the ViewModel's lifetime
       → HighlightsRepository.getAllHighlightsForBookFromDb(bookId): Flow<...>
         → HighlightDao.getAllHighlightsForBook(bookId): Flow<List<HighlightEntity>>
   ← sortedBy { savedOnTimestamp } → HighlightUIState list
@@ -131,8 +132,9 @@ This is the most involved flow and spans two ViewModels and three navigation des
 ```
 capture_and_crop_image/{bookId}
   → CaptureAndCropImageScreen + CaptureAndCropImageViewModel
-      imageUri = CreateTempImageFileUseCase()  → FileSource.createNewFile("<uuid>.jpg")
-                 (cacheDir file, exposed via FileProvider; stored in SavedStateHandle)
+      imageUri = savedStateHandle["imageUri"] ?: CreateTempImageFileUseCase().also { savedStateHandle["imageUri"] = it }
+                 (cacheDir file, exposed via FileProvider)
+      phase persisted in SavedStateHandle: CAPTURE → CROP → DONE
       state: CaptureImage → CropImage → ImageCapturedAndCropped
 ```
 
@@ -141,20 +143,27 @@ Steps ([`CaptureAndCropImageViewModel`](../feature-addhighlight/src/main/java/co
 1. **CaptureImage** — a `TakePicture` activity-result launcher writes the photo into the temp
    FileProvider URI. On cancel/failure the screen calls `goBack()`.
 2. **CropImage** — `CropImageScreen` (Cropify) lets the user crop; `onImageCropped()` advances state.
-3. **ImageCapturedAndCropped** — the screen calls `onImageCaptured(uri)`, which URL-encodes the URI
-   and navigates to `save_highlight_from_uri/{bookId}/{encodedUri}`.
+3. **ImageCapturedAndCropped** — a `LaunchedEffect(screenState)` calls `onImageCaptured(uri)`, which
+   URL-encodes the URI and navigates to `save_highlight_from_uri/{bookId}/{encodedUri}` (wrapped in
+   `LaunchedEffect` so a recomposition while already in this state can't re-navigate and duplicate the
+   back-stack entry).
 4. **Cleanup** — `onCleared()` deletes the temp file *unless* the flow completed
    (`ImageCapturedAndCropped`), so abandoned captures don't leak files. The completed file is handed
    off to the next screen, which deletes it after OCR.
+5. **Process death** — both `imageUri` and the phase are in `SavedStateHandle`, so a process death
+   mid-crop recreates the ViewModel back into `CropImage` with the same file instead of relaunching
+   the camera.
 
 ### 5b. OCR & save
 
 ```
 save_highlight_from_uri/{bookId}/{uri}
   → EditAndSaveHighlightScreen(uri) + EditAndSaveHighlightViewModel
-      processImageForHighlightText(uri):
+      hiltViewModel() populates SavedStateHandle with the encoded uri; init decodes it and calls
+      processImageForHighlightText(uri) once (guarded so a second call is a no-op):
         → TextAnalyzer.analyzeImage(uri)        (ML Kit on-device Latin OCR)
-        → visionText.text.replace("\n", " ")    → editable highlightText
+        → visionText.text.replace("\n", " ")    → editable highlightText, persisted as a draft in
+                                                    SavedStateHandle on every edit
         finally → DeleteFileUseCase(uri)         (delete the temp image)
 
 [user edits text, taps save]
@@ -171,20 +180,25 @@ Details:
   recognizer on cancellation. OCR runs fully on-device.
 - OCR failure → `image_processing_failure` snackbar; the temp file is deleted in `finally` either way.
 - A new highlight gets a random `UUID` and the current formatted timestamp.
+- The draft `highlightText` (and, for edits, `savedOnTimestamp`) live in `SavedStateHandle`, not just
+  in-memory `StateFlow` state, so an in-progress edit survives process death even though the source
+  image file has already been deleted by the time OCR finishes.
 
 ### 5c. Edit an existing highlight
 
 ```
 save_highlight_from_highlight_id/{bookId}/{highlightId}
-  → EditAndSaveHighlightViewModel.loadHighlightText(highlightId)
+  → hiltViewModel() populates SavedStateHandle with highlightId; init calls
+    loadHighlightText(highlightId) once (guarded so a second call is a no-op)
       → LoadHighlightUseCase → HighlightsRepository.loadHighlightFromDb → HighlightDao.getHighlightById
   ← prefilled text + screen title switches to "edit"; original savedOnTimestamp is preserved
 [save] → updateHighlight(bookId, text, highlightId)   (same UUID → REPLACE updates the row)
 ```
 
 The same [`EditAndSaveHighlightViewModel`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightViewModel.kt)
-serves both new and edit cases. For edits, `savedOnTimestamp` is retained so the original capture time
-is not overwritten, and the existing `highlightId` makes the REPLACE insert an update.
+serves both new and edit cases. For edits, `savedOnTimestamp` is retained (in `SavedStateHandle`) so
+the original capture time is not overwritten, and the existing `highlightId` makes the REPLACE insert
+an update.
 
 ---
 

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreen.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreen.kt
@@ -45,7 +45,9 @@ fun CaptureAndCropImageScreen(
         }
 
         is CaptureAndCropImageScreenState.ImageCapturedAndCropped -> {
-            onImageCaptured(screenState.imageUri)
+            LaunchedEffect(screenState) {
+                onImageCaptured(screenState.imageUri)
+            }
         }
     }
 }

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageViewModel.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageViewModel.kt
@@ -25,15 +25,25 @@ class CaptureAndCropImageViewModel @Inject constructor(
         }
     }
 
+    private var phase: CaptureAndCropImagePhase
+        get() = savedStateHandle.get<String>(PHASE_ARG)
+            ?.let { CaptureAndCropImagePhase.valueOf(it) }
+            ?: CaptureAndCropImagePhase.CAPTURE
+        set(value) {
+            savedStateHandle[PHASE_ARG] = value.name
+        }
+
     private val _screenState: MutableStateFlow<CaptureAndCropImageScreenState> =
-        MutableStateFlow(CaptureAndCropImageScreenState.CaptureImage(imageUri))
+        MutableStateFlow(phase.asScreenState(imageUri))
     internal val screenState: StateFlow<CaptureAndCropImageScreenState> = _screenState.asStateFlow()
 
     internal fun onImageCaptured() {
+        phase = CaptureAndCropImagePhase.CROP
         _screenState.update { CaptureAndCropImageScreenState.CropImage(imageUri) }
     }
 
     internal fun onImageCropped() {
+        phase = CaptureAndCropImagePhase.DONE
         _screenState.update { CaptureAndCropImageScreenState.ImageCapturedAndCropped(imageUri) }
     }
 
@@ -41,10 +51,26 @@ class CaptureAndCropImageViewModel @Inject constructor(
         if (screenState.value !is CaptureAndCropImageScreenState.ImageCapturedAndCropped) {
             deleteFileUseCase(imageUri)
             savedStateHandle.remove<Uri>("imageUri")
+            savedStateHandle.remove<String>(PHASE_ARG)
         }
         super.onCleared()
     }
+
+    private companion object {
+        private const val PHASE_ARG = "captureAndCropImagePhase"
+    }
 }
+
+private enum class CaptureAndCropImagePhase {
+    CAPTURE, CROP, DONE
+}
+
+private fun CaptureAndCropImagePhase.asScreenState(imageUri: Uri): CaptureAndCropImageScreenState =
+    when (this) {
+        CaptureAndCropImagePhase.CAPTURE -> CaptureAndCropImageScreenState.CaptureImage(imageUri)
+        CaptureAndCropImagePhase.CROP -> CaptureAndCropImageScreenState.CropImage(imageUri)
+        CaptureAndCropImagePhase.DONE -> CaptureAndCropImageScreenState.ImageCapturedAndCropped(imageUri)
+    }
 
 internal sealed interface CaptureAndCropImageScreenState {
     data class CaptureImage(val imageUri: Uri) : CaptureAndCropImageScreenState

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreen.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreen.kt
@@ -53,9 +53,6 @@ fun EditAndSaveHighlightScreen(
     bookId: String,
     goBack: () -> Unit
 ) {
-    LaunchedEffect(key1 = bookId) {
-        viewModel.processImageForHighlightText(uri)
-    }
     val editHighlightUiState: EditAndSaveHighlightUiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val resources = LocalResources.current
@@ -100,10 +97,6 @@ fun EditAndSaveHighlightScreen(
     bookId: String,
     goBack: () -> Unit
 ) {
-    LaunchedEffect(key1 = highlightId) {
-        viewModel.loadHighlightText(highlightId)
-    }
-
     val editHighlightUiState: EditAndSaveHighlightUiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val resources = LocalResources.current

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightViewModel.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightViewModel.kt
@@ -2,6 +2,7 @@ package com.sriniketh.feature_addhighlight
 
 import android.net.Uri
 import androidx.annotation.StringRes
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sriniketh.core_data.usecases.DeleteFileUseCase
@@ -10,6 +11,7 @@ import com.sriniketh.core_data.usecases.LoadHighlightUseCase
 import com.sriniketh.core_data.usecases.SaveHighlightUseCase
 import com.sriniketh.core_models.book.Highlight
 import com.sriniketh.core_platform.DateTimeSource
+import com.sriniketh.core_platform.decodeUri
 import com.sriniketh.core_platform.logTag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -32,20 +34,52 @@ class EditAndSaveHighlightViewModel @Inject constructor(
     private val saveHighlightUseCase: SaveHighlightUseCase,
     private val loadHighlightUseCase: LoadHighlightUseCase,
     private val formatCurrentDateTimeUseCase: FormatCurrentDateTimeUseCase,
-    private val deleteFileUseCase: DeleteFileUseCase
+    private val deleteFileUseCase: DeleteFileUseCase,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<EditAndSaveHighlightUiState> =
-        MutableStateFlow(EditAndSaveHighlightUiState())
+        MutableStateFlow(
+            EditAndSaveHighlightUiState(
+                highlightText = savedStateHandle.get<String>(DRAFT_HIGHLIGHT_TEXT_ARG).orEmpty()
+            )
+        )
     internal val uiState: StateFlow<EditAndSaveHighlightUiState> =
         _uiState.asStateFlow()
 
     private val _effects = Channel<EditAndSaveHighlightEffect>(Channel.BUFFERED)
     internal val effects: Flow<EditAndSaveHighlightEffect> = _effects.receiveAsFlow()
 
-    private var savedOnTimestamp: String? = null
+    private var savedOnTimestamp: String?
+        get() = savedStateHandle.get<String>(SAVED_ON_TIMESTAMP_ARG)
+        set(value) {
+            savedStateHandle[SAVED_ON_TIMESTAMP_ARG] = value
+        }
+    private var hasStartedProcessingImage = false
+    private var hasStartedLoadingHighlight = false
+
+    init {
+        val encodedUri = savedStateHandle.get<String>(URI_ARG)
+        val highlightId = savedStateHandle.get<String>(HIGHLIGHT_ID_ARG)
+        val hasDraft = savedStateHandle.get<String>(DRAFT_HIGHLIGHT_TEXT_ARG) != null
+
+        if (hasDraft) {
+            if (highlightId != null) {
+                _uiState.update { state -> state.copy(screenTitle = R.string.edit_highlight_title_text) }
+            }
+            hasStartedProcessingImage = true
+            hasStartedLoadingHighlight = true
+        } else if (encodedUri != null) {
+            processImageForHighlightText(encodedUri.decodeUri())
+        } else if (highlightId != null) {
+            loadHighlightText(highlightId)
+        }
+    }
 
     internal fun processImageForHighlightText(uri: Uri) {
+        if (hasStartedProcessingImage) return
+        hasStartedProcessingImage = true
+
         _uiState.update { state ->
             state.copy(isLoading = true)
         }
@@ -57,6 +91,7 @@ class EditAndSaveHighlightViewModel @Inject constructor(
                 _uiState.update { state ->
                     state.copy(isLoading = false, highlightText = highlightText)
                 }
+                savedStateHandle[DRAFT_HIGHLIGHT_TEXT_ARG] = highlightText
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (_: Exception) {
@@ -71,6 +106,9 @@ class EditAndSaveHighlightViewModel @Inject constructor(
     }
 
     internal fun loadHighlightText(highlightId: String) {
+        if (hasStartedLoadingHighlight) return
+        hasStartedLoadingHighlight = true
+
         _uiState.update { state ->
             state.copy(isLoading = true, screenTitle = R.string.edit_highlight_title_text)
         }
@@ -84,6 +122,7 @@ class EditAndSaveHighlightViewModel @Inject constructor(
                         highlightText = highlight?.text.orEmpty()
                     )
                 }
+                savedStateHandle[DRAFT_HIGHLIGHT_TEXT_ARG] = highlight?.text.orEmpty()
                 savedOnTimestamp = highlight?.savedOnTimestamp
             } else {
                 _uiState.update { state ->
@@ -98,6 +137,7 @@ class EditAndSaveHighlightViewModel @Inject constructor(
         _uiState.update { state ->
             state.copy(highlightText = highlightText)
         }
+        savedStateHandle[DRAFT_HIGHLIGHT_TEXT_ARG] = highlightText
     }
 
     internal fun saveHighlight(bookId: String, highlightText: String) {
@@ -142,6 +182,13 @@ class EditAndSaveHighlightViewModel @Inject constructor(
                 _effects.trySend(EditAndSaveHighlightEffect.ShowMessage(R.string.save_highlight_error_message))
             }
         }
+    }
+
+    private companion object {
+        private const val URI_ARG = "uri"
+        private const val HIGHLIGHT_ID_ARG = "highlightId"
+        private const val DRAFT_HIGHLIGHT_TEXT_ARG = "draftHighlightText"
+        private const val SAVED_ON_TIMESTAMP_ARG = "savedOnTimestamp"
     }
 }
 

--- a/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageViewModelTest.kt
+++ b/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageViewModelTest.kt
@@ -1,0 +1,130 @@
+package com.sriniketh.feature_addhighlight
+
+import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
+import com.sriniketh.core_data.usecases.CreateTempImageFileUseCase
+import com.sriniketh.core_data.usecases.DeleteFileUseCase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class CaptureAndCropImageViewModelTest {
+
+    private lateinit var createTempImageFileUseCase: CreateTempImageFileUseCase
+    private lateinit var deleteFileUseCase: DeleteFileUseCase
+    private lateinit var fakeUri: Uri
+
+    @Before
+    fun setup() {
+        fakeUri = mockk()
+        createTempImageFileUseCase = mockk()
+        every { createTempImageFileUseCase() } returns fakeUri
+        deleteFileUseCase = mockk()
+        every { deleteFileUseCase(any()) } returns true
+    }
+
+    private fun buildViewModel(
+        savedStateHandle: SavedStateHandle = SavedStateHandle()
+    ): CaptureAndCropImageViewModel = CaptureAndCropImageViewModel(
+        createTempImageFileUseCase,
+        deleteFileUseCase,
+        savedStateHandle
+    )
+
+    @Test
+    fun `when created then screen state starts at CaptureImage`() {
+        val viewModel = buildViewModel()
+
+        assertTrue(viewModel.screenState.value is CaptureAndCropImageScreenState.CaptureImage)
+    }
+
+    @Test
+    fun `when onImageCaptured is called then screen state moves to CropImage`() {
+        val viewModel = buildViewModel()
+
+        viewModel.onImageCaptured()
+
+        assertTrue(viewModel.screenState.value is CaptureAndCropImageScreenState.CropImage)
+    }
+
+    @Test
+    fun `when onImageCropped is called then screen state moves to ImageCapturedAndCropped`() {
+        val viewModel = buildViewModel()
+
+        viewModel.onImageCaptured()
+        viewModel.onImageCropped()
+
+        assertTrue(viewModel.screenState.value is CaptureAndCropImageScreenState.ImageCapturedAndCropped)
+    }
+
+    @Test
+    fun `when recreated with same SavedStateHandle after image captured then resumes at CropImage instead of relaunching the camera`() {
+        val savedStateHandle = SavedStateHandle()
+        val originalViewModel = buildViewModel(savedStateHandle)
+        originalViewModel.onImageCaptured()
+
+        val recreatedViewModel = buildViewModel(savedStateHandle)
+
+        assertTrue(recreatedViewModel.screenState.value is CaptureAndCropImageScreenState.CropImage)
+    }
+
+    @Test
+    fun `when recreated with same SavedStateHandle after image cropped then resumes at ImageCapturedAndCropped`() {
+        val savedStateHandle = SavedStateHandle()
+        val originalViewModel = buildViewModel(savedStateHandle)
+        originalViewModel.onImageCaptured()
+        originalViewModel.onImageCropped()
+
+        val recreatedViewModel = buildViewModel(savedStateHandle)
+
+        assertTrue(recreatedViewModel.screenState.value is CaptureAndCropImageScreenState.ImageCapturedAndCropped)
+    }
+
+    @Test
+    fun `when recreated with same SavedStateHandle then reuses the same imageUri instead of creating a new temp file`() {
+        val savedStateHandle = SavedStateHandle()
+        val originalViewModel = buildViewModel(savedStateHandle)
+        originalViewModel.onImageCaptured()
+        val originalUri =
+            (originalViewModel.screenState.value as CaptureAndCropImageScreenState.CropImage).imageUri
+
+        val recreatedViewModel = buildViewModel(savedStateHandle)
+        val recreatedUri =
+            (recreatedViewModel.screenState.value as CaptureAndCropImageScreenState.CropImage).imageUri
+
+        assertEquals(originalUri, recreatedUri)
+        verify(exactly = 1) { createTempImageFileUseCase() }
+    }
+
+    @Test
+    fun `when cleared before crop completes then temp file is deleted`() {
+        val savedStateHandle = SavedStateHandle()
+        val viewModel = buildViewModel(savedStateHandle)
+        viewModel.onImageCaptured()
+        val store = ViewModelStore()
+        store.put("key", viewModel)
+
+        store.clear()
+
+        verify(exactly = 1) { deleteFileUseCase(fakeUri) }
+    }
+
+    @Test
+    fun `when cleared after crop completes then temp file is not deleted`() {
+        val savedStateHandle = SavedStateHandle()
+        val viewModel = buildViewModel(savedStateHandle)
+        viewModel.onImageCaptured()
+        viewModel.onImageCropped()
+        val store = ViewModelStore()
+        store.put("key", viewModel)
+
+        store.clear()
+
+        verify(exactly = 0) { deleteFileUseCase(any()) }
+    }
+}

--- a/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightViewModelTest.kt
+++ b/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.sriniketh.feature_addhighlight
 
 import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.sriniketh.core_data.usecases.DeleteFileUseCase
 import com.sriniketh.core_data.usecases.FormatCurrentDateTimeUseCase
@@ -10,7 +11,10 @@ import com.sriniketh.feature_addhighlight.fakes.FakeDateTimeSource
 import com.sriniketh.feature_addhighlight.fakes.FakeFileSource
 import com.sriniketh.feature_addhighlight.fakes.FakeHighlightsRepository
 import com.sriniketh.feature_addhighlight.fakes.FakeTextAnalyzer
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -48,21 +52,26 @@ class EditAndSaveHighlightViewModelTest {
         loadHighlightUseCase = LoadHighlightUseCase(fakeHighlightsRepository)
         formatCurrentDateTimeUseCase = FormatCurrentDateTimeUseCase()
         deleteFileUseCase = DeleteFileUseCase(fakeFileSource)
-        
-        viewModel = EditAndSaveHighlightViewModel(
-            dateTimeSource = fakeDateTimeSource,
-            textAnalyzer = fakeTextAnalyzer,
-            saveHighlightUseCase = saveHighlightUseCase,
-            loadHighlightUseCase = loadHighlightUseCase,
-            formatCurrentDateTimeUseCase = formatCurrentDateTimeUseCase,
-            deleteFileUseCase = deleteFileUseCase
-        )
+
+        viewModel = buildViewModel()
     }
 
     @After
     fun tearDown() {
         Dispatchers.resetMain()
     }
+
+    private fun buildViewModel(
+        savedStateHandle: SavedStateHandle = SavedStateHandle()
+    ): EditAndSaveHighlightViewModel = EditAndSaveHighlightViewModel(
+        dateTimeSource = fakeDateTimeSource,
+        textAnalyzer = fakeTextAnalyzer,
+        saveHighlightUseCase = saveHighlightUseCase,
+        loadHighlightUseCase = loadHighlightUseCase,
+        formatCurrentDateTimeUseCase = formatCurrentDateTimeUseCase,
+        deleteFileUseCase = deleteFileUseCase,
+        savedStateHandle = savedStateHandle
+    )
 
     @Test
     fun `when initialized then state has correct defaults`() = runTest {
@@ -279,4 +288,107 @@ class EditAndSaveHighlightViewModelTest {
 
         assertFalse(viewModel.uiState.value.isLoading)
     }
+
+    @Test
+    fun `when created with a uri in SavedStateHandle then processes the image automatically`() = runTest {
+        fakeTextAnalyzer.textToReturn = "Text from auto-processed image"
+        mockkStatic(Uri::class)
+        every { Uri.decode(any()) } answers { firstArg() }
+        every { Uri.parse(any()) } returns mockk(relaxed = true)
+        try {
+            val savedStateHandle = SavedStateHandle(mapOf("uri" to "content://test/image.jpg"))
+
+            val autoInitViewModel = buildViewModel(savedStateHandle)
+
+            autoInitViewModel.uiState.test {
+                awaitItem()
+                val loadedState = awaitItem()
+                assertEquals("Text from auto-processed image", loadedState.highlightText)
+            }
+            assertEquals(1, fakeTextAnalyzer.analyzeImageInvocationCount)
+        } finally {
+            unmockkStatic(Uri::class)
+        }
+    }
+
+    @Test
+    fun `when created with a highlightId in SavedStateHandle then loads the highlight automatically`() = runTest {
+        val savedStateHandle = SavedStateHandle(mapOf("highlightId" to "test-highlight-id"))
+
+        val autoInitViewModel = buildViewModel(savedStateHandle)
+
+        autoInitViewModel.uiState.test {
+            awaitItem()
+            val loadedState = awaitItem()
+            assertEquals("Test highlight text", loadedState.highlightText)
+        }
+        assertEquals(1, fakeHighlightsRepository.loadHighlightFromDbInvocationCount)
+    }
+
+    @Test
+    fun `when process image for highlight text is called twice then only processes once`() = runTest {
+        val fakeUri = mockk<Uri>()
+
+        viewModel.processImageForHighlightText(fakeUri)
+        viewModel.processImageForHighlightText(fakeUri)
+        advanceUntilIdle()
+
+        assertEquals(1, fakeTextAnalyzer.analyzeImageInvocationCount)
+        assertEquals(1, fakeFileSource.deletedUris.size)
+    }
+
+    @Test
+    fun `when load highlight text is called twice then only loads once`() = runTest {
+        viewModel.loadHighlightText("highlight-id")
+        viewModel.loadHighlightText("highlight-id")
+        advanceUntilIdle()
+
+        assertEquals(1, fakeHighlightsRepository.loadHighlightFromDbInvocationCount)
+    }
+
+    @Test
+    fun `when updateHighlightText is called then draft is persisted to SavedStateHandle`() = runTest {
+        val savedStateHandle = SavedStateHandle()
+        val originalViewModel = buildViewModel(savedStateHandle)
+
+        originalViewModel.updateHighlightText("in progress edit")
+
+        val recreatedViewModel = buildViewModel(savedStateHandle)
+
+        assertEquals("in progress edit", recreatedViewModel.uiState.value.highlightText)
+    }
+
+    @Test
+    fun `when recreated after process death with a draft then it does not reprocess the deleted image`() = runTest {
+        val savedStateHandle = SavedStateHandle(
+            mapOf(
+                "uri" to "content://test/image.jpg",
+                "draftHighlightText" to "recovered draft text"
+            )
+        )
+
+        val recreatedViewModel = buildViewModel(savedStateHandle)
+        advanceUntilIdle()
+
+        assertEquals("recovered draft text", recreatedViewModel.uiState.value.highlightText)
+        assertEquals(0, fakeTextAnalyzer.analyzeImageInvocationCount)
+    }
+
+    @Test
+    fun `when recreated after process death with a draft for an existing highlight then title reflects edit mode`() =
+        runTest {
+            val savedStateHandle = SavedStateHandle(
+                mapOf(
+                    "highlightId" to "test-highlight-id",
+                    "draftHighlightText" to "recovered draft text"
+                )
+            )
+
+            val recreatedViewModel = buildViewModel(savedStateHandle)
+            advanceUntilIdle()
+
+            assertEquals("recovered draft text", recreatedViewModel.uiState.value.highlightText)
+            assertEquals(R.string.edit_highlight_title_text, recreatedViewModel.uiState.value.screenTitle)
+            assertEquals(0, fakeHighlightsRepository.loadHighlightFromDbInvocationCount)
+        }
 }

--- a/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/fakes/FakeHighlightsRepository.kt
+++ b/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/fakes/FakeHighlightsRepository.kt
@@ -14,6 +14,7 @@ class FakeHighlightsRepository : HighlightsRepository {
 
     var insertedHighlight: Highlight? = null
     var loadedHighlightId: String? = null
+    var loadHighlightFromDbInvocationCount = 0
 
     private val fakeHighlight = Highlight(
         id = "test-highlight-id",
@@ -49,6 +50,7 @@ class FakeHighlightsRepository : HighlightsRepository {
 
     override suspend fun loadHighlightFromDb(highlightId: String): Result<Highlight> {
         loadedHighlightId = highlightId
+        loadHighlightFromDbInvocationCount++
         return if (shouldLoadHighlightFromDbThrowException) {
             Result.failure(RuntimeException("Load highlight failed"))
         } else {

--- a/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/fakes/FakeTextAnalyzer.kt
+++ b/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/fakes/FakeTextAnalyzer.kt
@@ -11,9 +11,11 @@ class FakeTextAnalyzer : TextAnalyzer {
     var shouldThrowException = false
     var analyzedUri: Uri? = null
     var textToReturn = "Fake analyzed text from image"
+    var analyzeImageInvocationCount = 0
 
     override suspend fun analyzeImage(uri: Uri): Text {
         analyzedUri = uri
+        analyzeImageInvocationCount++
         if (shouldThrowException) {
             throw RuntimeException("Text analysis failed")
         }

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -63,13 +63,9 @@ import kotlinx.coroutines.launch
 fun BookInfoScreen(
     modifier: Modifier = Modifier,
     viewModel: BookInfoViewModel = hiltViewModel(),
-    bookId: String,
     goBack: () -> Unit,
     onBookAddedToShelf: () -> Unit = {}
 ) {
-    LaunchedEffect(key1 = bookId) {
-        viewModel.getBookDetail(bookId)
-    }
     val uiState: BookInfoUiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val resources = LocalResources.current

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt
@@ -1,6 +1,7 @@
 package com.sriniketh.feature_searchbooks
 
 import androidx.annotation.StringRes
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sriniketh.core_data.usecases.AddBookToShelfUseCase
@@ -25,17 +26,29 @@ import javax.inject.Inject
 class BookInfoViewModel @Inject constructor(
     private val fetchBookInfoUseCase: FetchBookInfoUseCase,
     private val addBookToShelfUseCase: AddBookToShelfUseCase,
-    private val isBookInDbUseCase: IsBookInDbUseCase
+    private val isBookInDbUseCase: IsBookInDbUseCase,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
+    private val bookId: String = savedStateHandle.get<String>(BOOK_ID_ARG).orEmpty()
+
     private val _uiState: MutableStateFlow<BookInfoUiState> =
-        MutableStateFlow(BookInfoUiState())
+        MutableStateFlow(BookInfoUiState(isLoading = true))
     internal val uiState: StateFlow<BookInfoUiState> = _uiState.asStateFlow()
 
     private val _effects = Channel<BookInfoEffect>(Channel.BUFFERED)
     internal val effects: Flow<BookInfoEffect> = _effects.receiveAsFlow()
 
+    private var hasStartedLoadingBookDetail = false
+
+    init {
+        getBookDetail(bookId)
+    }
+
     fun getBookDetail(volumeId: String) {
+        if (hasStartedLoadingBookDetail) return
+        hasStartedLoadingBookDetail = true
+
         viewModelScope.launch {
             _uiState.update { state ->
                 state.copy(isLoading = true)
@@ -95,6 +108,10 @@ class BookInfoViewModel @Inject constructor(
         averageRating = info.averageRating,
         ratingsCount = info.ratingsCount
     )
+
+    private companion object {
+        private const val BOOK_ID_ARG = "bookId"
+    }
 }
 
 data class BookInfoUiState(

--- a/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/BookInfoViewModelTest.kt
+++ b/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/BookInfoViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.sriniketh.feature_searchbooks
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.sriniketh.core_data.usecases.AddBookToShelfUseCase
 import com.sriniketh.core_data.usecases.FetchBookInfoUseCase
@@ -29,6 +30,8 @@ class BookInfoViewModelTest {
     private lateinit var isBookInDbUseCase: IsBookInDbUseCase
     private lateinit var viewModel: BookInfoViewModel
 
+    private val volumeId = "test-volume-id"
+
     @Before
     fun setup() {
         Dispatchers.setMain(StandardTestDispatcher())
@@ -36,11 +39,7 @@ class BookInfoViewModelTest {
         fetchBookInfoUseCase = FetchBookInfoUseCase(fakeBooksRepository)
         addBookToShelfUseCase = AddBookToShelfUseCase(fakeBooksRepository)
         isBookInDbUseCase = IsBookInDbUseCase(fakeBooksRepository)
-        viewModel = BookInfoViewModel(
-            fetchBookInfoUseCase,
-            addBookToShelfUseCase,
-            isBookInDbUseCase
-        )
+        viewModel = buildViewModel()
     }
 
     @After
@@ -48,80 +47,75 @@ class BookInfoViewModelTest {
         Dispatchers.resetMain()
     }
 
+    private fun buildViewModel(bookId: String = volumeId): BookInfoViewModel = BookInfoViewModel(
+        fetchBookInfoUseCase,
+        addBookToShelfUseCase,
+        isBookInDbUseCase,
+        SavedStateHandle(mapOf("bookId" to bookId))
+    )
+
     @Test
-    fun `when get book detail is called then loading state is set to true`() = runTest {
-        viewModel.uiState.test {
-            val initialState = awaitItem()
-            assertFalse(initialState.isLoading)
+    fun `when created then reads bookId from SavedStateHandle and loads book detail automatically`() = runTest {
+        advanceUntilIdle()
 
-            viewModel.getBookDetail("test-volume-id")
+        assertFalse(viewModel.uiState.value.isLoading)
+        assertEquals(volumeId, fakeBooksRepository.volumeIdPassed)
+    }
 
-            val loadingState = awaitItem()
-            assertTrue(loadingState.isLoading)
+    @Test
+    fun `when get book detail is called again after initial load then it is ignored`() = runTest {
+        advanceUntilIdle()
+        assertEquals(1, fakeBooksRepository.fetchBookInfoInvocationCount)
 
-            skipItems(1)
-        }
+        viewModel.getBookDetail("some-other-id")
+        advanceUntilIdle()
+
+        assertEquals(1, fakeBooksRepository.fetchBookInfoInvocationCount)
+        assertEquals(volumeId, fakeBooksRepository.volumeIdPassed)
     }
 
     @Test
     fun `when get book detail succeeds then book info and can add to shelf are set`() = runTest {
         fakeBooksRepository.doesBookExistResult = false
+        advanceUntilIdle()
 
-        viewModel.uiState.test {
-            awaitItem()
-
-            viewModel.getBookDetail("test-volume-id")
-
-            skipItems(1)
-
-            val successState = awaitItem()
-            assertFalse(successState.isLoading)
-            assertNotNull(successState.book)
-            assertEquals("Test Title", successState.book?.title)
-            assertTrue(successState.canAddToShelf)
-        }
+        val successState = viewModel.uiState.value
+        assertFalse(successState.isLoading)
+        assertNotNull(successState.book)
+        assertEquals("Test Title", successState.book?.title)
+        assertTrue(successState.canAddToShelf)
     }
 
     @Test
     fun `when get book detail succeeds and book exists then can add to shelf is set to false`() =
         runTest {
             fakeBooksRepository.doesBookExistResult = true
+            val viewModelWithExistingBook = buildViewModel()
+            advanceUntilIdle()
 
-            viewModel.uiState.test {
-                awaitItem()
-
-                viewModel.getBookDetail("test-volume-id")
-
-                skipItems(1)
-
-                val successState = awaitItem()
-                assertFalse(successState.isLoading)
-                assertNotNull(successState.book)
-                assertFalse(successState.canAddToShelf)
-            }
+            val successState = viewModelWithExistingBook.uiState.value
+            assertFalse(successState.isLoading)
+            assertNotNull(successState.book)
+            assertFalse(successState.canAddToShelf)
         }
 
     @Test
     fun `when get book detail fails then loading is set to false and error is shown`() = runTest {
         fakeBooksRepository.shouldFetchBookInfoThrowException = true
+        val failingViewModel = buildViewModel()
 
-        viewModel.effects.test {
-            viewModel.getBookDetail("test-volume-id")
-
+        failingViewModel.effects.test {
             assertEquals(
                 BookInfoEffect.ShowMessage(R.string.book_info_load_error_message),
                 awaitItem()
             )
         }
 
-        assertFalse(viewModel.uiState.value.isLoading)
+        assertFalse(failingViewModel.uiState.value.isLoading)
     }
 
     @Test
-    fun `when get book detail is called then volume id is passed to use case`() = runTest {
-        val volumeId = "test-volume-id"
-
-        viewModel.getBookDetail(volumeId)
+    fun `when created then bookId is passed to use case`() = runTest {
         advanceUntilIdle()
 
         assertEquals(volumeId, fakeBooksRepository.volumeIdPassed)
@@ -130,8 +124,6 @@ class BookInfoViewModelTest {
     @Test
     fun `when add book to shelf is called then repository insert is invoked`() = runTest {
         fakeBooksRepository.doesBookExistResult = false
-
-        viewModel.getBookDetail("test-volume-id")
         advanceUntilIdle()
 
         val currentState = viewModel.uiState.value
@@ -148,8 +140,6 @@ class BookInfoViewModelTest {
     @Test
     fun `when add book to shelf succeeds then can add to shelf becomes false`() = runTest {
         fakeBooksRepository.doesBookExistResult = false
-
-        viewModel.getBookDetail("test-volume-id")
         advanceUntilIdle()
 
         val beforeAddState = viewModel.uiState.value
@@ -165,8 +155,6 @@ class BookInfoViewModelTest {
     @Test
     fun `when add book to shelf succeeds then navigate to bookshelf effect is emitted`() = runTest {
         fakeBooksRepository.doesBookExistResult = false
-
-        viewModel.getBookDetail("test-volume-id")
         advanceUntilIdle()
 
         val addToShelf = viewModel.uiState.value.addBookToShelf
@@ -178,17 +166,6 @@ class BookInfoViewModelTest {
                 BookInfoEffect.NavigateToBookshelf,
                 awaitItem()
             )
-        }
-    }
-
-    @Test
-    fun `when initialized then state has correct defaults`() = runTest {
-        viewModel.uiState.test {
-            val initialState = awaitItem()
-
-            assertFalse(initialState.isLoading)
-            assertEquals(null, initialState.book)
-            assertFalse(initialState.canAddToShelf)
         }
     }
 }

--- a/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/fakes/FakeBooksRepository.kt
+++ b/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/fakes/FakeBooksRepository.kt
@@ -23,6 +23,7 @@ class FakeBooksRepository : BooksRepository {
 	var insertedBook: Book? = null
 	var deletedBook: Book? = null
 	var doesBookExistResult = false
+	var fetchBookInfoInvocationCount = 0
 
 	val queriesSearched: MutableList<String> = mutableListOf()
 	var searchDelayMillis: Long = 0L
@@ -59,6 +60,7 @@ class FakeBooksRepository : BooksRepository {
 
 	override suspend fun fetchBookInfo(volumeId: String): Result<Book> {
 		volumeIdPassed = volumeId
+		fetchBookInfoInvocationCount++
 		return if (shouldFetchBookInfoThrowException) {
 			Result.failure(RuntimeException("Fetch book info failed"))
 		} else {

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -78,9 +78,6 @@ fun ViewHighlightsScreen(
     goToAddHighlightScreen: () -> Unit,
     goToEditHighlightScreen: (String) -> Unit
 ) {
-    LaunchedEffect(key1 = bookId) {
-        viewModel.getHighlights(bookId)
-    }
     val uiState: ViewHighlightsUIState by viewModel.highlightsUIStateFlow.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModel.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModel.kt
@@ -2,6 +2,7 @@ package com.sriniketh.feature_viewhighlights
 
 import android.net.Uri
 import androidx.annotation.StringRes
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sriniketh.core_data.usecases.DeleteHighlightUseCase
@@ -26,22 +27,26 @@ import javax.inject.Inject
 class ViewHighlightsViewModel @Inject constructor(
     private val getAllSavedHighlightsUseCase: GetAllSavedHighlightsUseCase,
     private val deleteHighlightUseCase: DeleteHighlightUseCase,
-    private val exportHighlightsUseCase: ExportHighlightsUseCase
+    private val exportHighlightsUseCase: ExportHighlightsUseCase,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
+    private val bookId: String = savedStateHandle.get<String>(BOOK_ID_ARG).orEmpty()
+
     private val _highlightsUIStateFlow: MutableStateFlow<ViewHighlightsUIState> =
-        MutableStateFlow(ViewHighlightsUIState())
+        MutableStateFlow(ViewHighlightsUIState(isLoading = true))
     internal val highlightsUIStateFlow: StateFlow<ViewHighlightsUIState> =
         _highlightsUIStateFlow.asStateFlow()
 
     private val _effects = Channel<ViewHighlightsEffect>(Channel.BUFFERED)
     internal val effects: Flow<ViewHighlightsEffect> = _effects.receiveAsFlow()
 
-    internal fun getHighlights(bookId: String) {
+    init {
+        loadHighlights()
+    }
+
+    private fun loadHighlights() {
         viewModelScope.launch {
-            _highlightsUIStateFlow.update { state ->
-                state.copy(isLoading = true)
-            }
             getAllSavedHighlightsUseCase(bookId).collect { result ->
                 if (result.isSuccess) {
                     val highlights = result.getOrThrow().sortedBy { it.savedOnTimestamp }
@@ -53,7 +58,7 @@ class ViewHighlightsViewModel @Inject constructor(
                     }
                 } else if (result.isFailure) {
                     _highlightsUIStateFlow.update { state ->
-                        state.copy(isLoading = false)
+                        state.copy(isLoading = false, highlights = persistentListOf())
                     }
                     _effects.trySend(ViewHighlightsEffect.ShowMessage(R.string.gethighlights_error_message))
                 }
@@ -122,6 +127,10 @@ class ViewHighlightsViewModel @Inject constructor(
         text = text,
         savedOn = savedOnTimestamp
     )
+
+    private companion object {
+        private const val BOOK_ID_ARG = "bookId"
+    }
 }
 
 internal data class ViewHighlightsUIState(

--- a/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModelTest.kt
+++ b/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.sriniketh.feature_viewhighlights
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.sriniketh.core_data.usecases.DeleteHighlightUseCase
 import com.sriniketh.core_data.usecases.ExportHighlightsUseCase
@@ -10,6 +11,7 @@ import com.sriniketh.feature_viewhighlights.fakes.FakeHighlightsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -30,7 +32,8 @@ class ViewHighlightsViewModelTest {
     private lateinit var getAllSavedHighlightsUseCase: GetAllSavedHighlightsUseCase
     private lateinit var deleteHighlightUseCase: DeleteHighlightUseCase
     private lateinit var exportHighlightsUseCase: ExportHighlightsUseCase
-    private lateinit var viewModel: ViewHighlightsViewModel
+
+    private val bookId = "test-book-id"
 
     @Before
     fun setup() {
@@ -41,11 +44,6 @@ class ViewHighlightsViewModelTest {
         getAllSavedHighlightsUseCase = GetAllSavedHighlightsUseCase(fakeHighlightsRepository)
         deleteHighlightUseCase = DeleteHighlightUseCase(fakeHighlightsRepository)
         exportHighlightsUseCase = ExportHighlightsUseCase(fakeBooksRepository, fakeHighlightsRepository, fakeFileSource)
-        viewModel = ViewHighlightsViewModel(
-            getAllSavedHighlightsUseCase,
-            deleteHighlightUseCase,
-            exportHighlightsUseCase
-        )
     }
 
     @After
@@ -53,182 +51,78 @@ class ViewHighlightsViewModelTest {
         Dispatchers.resetMain()
     }
 
+    private fun buildViewModel(bookId: String = this.bookId): ViewHighlightsViewModel =
+        ViewHighlightsViewModel(
+            getAllSavedHighlightsUseCase,
+            deleteHighlightUseCase,
+            exportHighlightsUseCase,
+            SavedStateHandle(mapOf("bookId" to bookId))
+        )
+
     @Test
-    fun `when getHighlights is called then sets loading state to true`() = runTest {
+    fun `when created then reads bookId from SavedStateHandle and loads highlights automatically`() = runTest {
+        val viewModel = buildViewModel()
+
         viewModel.highlightsUIStateFlow.test {
-            val initialState = awaitItem()
-            assertFalse(initialState.isLoading)
-
-            viewModel.getHighlights("test-book-id")
-
             val loadingState = awaitItem()
             assertTrue(loadingState.isLoading)
 
-            skipItems(1)
+            val loadedState = awaitItem()
+            assertFalse(loadedState.isLoading)
+            assertEquals(1, loadedState.highlights.size)
+            assertEquals("test-highlight-id", loadedState.highlights[0].id)
         }
-    }
-
-    @Test
-    fun `when getHighlights succeeds then returns highlights`() = runTest {
-        val bookId = "test-book-id"
-        fakeHighlightsRepository.shouldGetAllHighlightsForBookFromDbThrowException = false
-
-        viewModel.highlightsUIStateFlow.test {
-            awaitItem()
-
-            viewModel.getHighlights(bookId)
-
-            awaitItem()
-            val finalState = awaitItem()
-            assertFalse(finalState.isLoading)
-            assertEquals(1, finalState.highlights.size)
-            assertEquals("test-highlight-id", finalState.highlights[0].id)
-        }
-    }
-
-    @Test
-    fun `when getHighlights succeeds then passes book id to repository`() = runTest {
-        val bookId = "test-book-id"
-
-        viewModel.getHighlights(bookId)
-        this.testScheduler.advanceUntilIdle()
 
         assertEquals(bookId, fakeHighlightsRepository.bookIdPassed)
     }
 
     @Test
-    fun `when getHighlights fails then shows error message`() = runTest {
-        val bookId = "test-book-id"
+    fun `when ViewModel is only created once then repository is only collected once regardless of how many observers subscribe`() =
+        runTest {
+            val viewModel = buildViewModel()
+            advanceUntilIdle()
+
+            assertEquals(1, fakeHighlightsRepository.getAllHighlightsForBookFromDbInvocationCount)
+
+            viewModel.highlightsUIStateFlow.test { awaitItem() }
+            viewModel.highlightsUIStateFlow.test { awaitItem() }
+            viewModel.highlightsUIStateFlow.test { awaitItem() }
+
+            assertEquals(1, fakeHighlightsRepository.getAllHighlightsForBookFromDbInvocationCount)
+        }
+
+    @Test
+    fun `when getAllSavedHighlights fails then shows error message exactly once`() = runTest {
         fakeHighlightsRepository.shouldGetAllHighlightsForBookFromDbThrowException = true
+        val viewModel = buildViewModel()
 
         viewModel.effects.test {
-            viewModel.getHighlights(bookId)
-
             assertEquals(
                 ViewHighlightsEffect.ShowMessage(R.string.gethighlights_error_message),
                 awaitItem()
             )
+            expectNoEvents()
         }
-
-        assertFalse(viewModel.highlightsUIStateFlow.value.isLoading)
     }
 
     @Test
-    fun `when getHighlights fails then clears highlights list`() = runTest {
-        val bookId = "test-book-id"
+    fun `when getAllSavedHighlights fails then clears highlights list`() = runTest {
         fakeHighlightsRepository.shouldGetAllHighlightsForBookFromDbThrowException = true
+        val viewModel = buildViewModel()
 
         viewModel.highlightsUIStateFlow.test {
-            awaitItem()
-
-            viewModel.getHighlights(bookId)
-
             awaitItem()
             val errorState = awaitItem()
             assertTrue(errorState.highlights.isEmpty())
+            assertFalse(errorState.isLoading)
         }
-    }
-
-    @Test
-    fun `when processing OnCameraPermissionDenied action then shows permission error`() = runTest {
-        viewModel.effects.test {
-            viewModel.processAction(ViewHighlightsAction.OnCameraPermissionDenied)
-
-            assertEquals(
-                ViewHighlightsEffect.ShowMessage(R.string.permission_denied_error_message),
-                awaitItem()
-            )
-        }
-
-        assertFalse(viewModel.highlightsUIStateFlow.value.isLoading)
-    }
-
-    @Test
-    fun `when processing other actions then does nothing`() = runTest {
-        viewModel.processAction(ViewHighlightsAction.OnBackPressed)
-
-        viewModel.highlightsUIStateFlow.test {
-            val state = awaitItem()
-            assertFalse(state.isLoading)
-            assertTrue(state.highlights.isEmpty())
-        }
-    }
-
-    @Test
-    fun `when delete action is processed then sets loading state`() = runTest {
-        val bookId = "test-book-id"
-        fakeHighlightsRepository.shouldGetAllHighlightsForBookFromDbThrowException = false
-
-        viewModel.highlightsUIStateFlow.test {
-            awaitItem()
-
-            viewModel.getHighlights(bookId)
-            awaitItem()
-            val stateWithHighlights = awaitItem()
-
-            viewModel.processAction(
-                ViewHighlightsAction.OnDeleteHighlight(stateWithHighlights.highlights.first().id)
-            )
-            val loadingState = awaitItem()
-            assertTrue(loadingState.isLoading)
-        }
-    }
-
-    @Test
-    fun `when delete action succeeds then passes highlight to repository`() = runTest {
-        val bookId = "test-book-id"
-        fakeHighlightsRepository.shouldGetAllHighlightsForBookFromDbThrowException = false
-
-        viewModel.getHighlights(bookId)
-        this.testScheduler.advanceUntilIdle()
-
-        viewModel.highlightsUIStateFlow.test {
-            val state = awaitItem()
-            viewModel.processAction(
-                ViewHighlightsAction.OnDeleteHighlight(state.highlights.first().id)
-            )
-
-            awaitItem()
-        }
-
-        this.testScheduler.advanceUntilIdle()
-        assertEquals("test-highlight-id", fakeHighlightsRepository.deletedHighlightId)
-    }
-
-    @Test
-    fun `when delete action fails then shows error message`() = runTest {
-        val bookId = "test-book-id"
-        fakeHighlightsRepository.shouldGetAllHighlightsForBookFromDbThrowException = false
-        fakeHighlightsRepository.shouldDeleteHighlightFromDbThrowException = true
-
-        viewModel.getHighlights(bookId)
-        this.testScheduler.advanceUntilIdle()
-
-        viewModel.effects.test {
-            viewModel.processAction(
-                ViewHighlightsAction.OnDeleteHighlight(
-                    viewModel.highlightsUIStateFlow.value.highlights.first().id
-                )
-            )
-
-            assertEquals(
-                ViewHighlightsEffect.ShowMessage(R.string.delete_error_message),
-                awaitItem()
-            )
-        }
-
-        assertFalse(viewModel.highlightsUIStateFlow.value.isLoading)
     }
 
     @Test
     fun `when highlight is mapped to UI state then all fields are correct`() = runTest {
-        val bookId = "test-book-id"
-        fakeHighlightsRepository.shouldGetAllHighlightsForBookFromDbThrowException = false
+        val viewModel = buildViewModel()
 
         viewModel.highlightsUIStateFlow.test {
-            awaitItem()
-
-            viewModel.getHighlights(bookId)
             awaitItem()
             val state = awaitItem()
 
@@ -240,12 +134,100 @@ class ViewHighlightsViewModelTest {
     }
 
     @Test
-    fun `when OnExportHighlights action is processed then sets loading state to true`() = runTest {
+    fun `when processing OnCameraPermissionDenied action then shows permission error`() = runTest {
+        val viewModel = buildViewModel()
+
+        viewModel.effects.test {
+            viewModel.processAction(ViewHighlightsAction.OnCameraPermissionDenied)
+
+            assertEquals(
+                ViewHighlightsEffect.ShowMessage(R.string.permission_denied_error_message),
+                awaitItem()
+            )
+        }
+    }
+
+    @Test
+    fun `when processing other actions then does nothing`() = runTest {
+        val viewModel = buildViewModel()
+        viewModel.processAction(ViewHighlightsAction.OnBackPressed)
+
         viewModel.highlightsUIStateFlow.test {
             awaitItem()
+            val state = awaitItem()
+            assertFalse(state.isLoading)
+            assertEquals(1, state.highlights.size)
+        }
+    }
 
-            viewModel.processAction(ViewHighlightsAction.OnExportHighlights("test-book-id"))
-            testScheduler.advanceUntilIdle()
+    @Test
+    fun `when delete action is processed then sets loading state`() = runTest {
+        val viewModel = buildViewModel()
+
+        viewModel.highlightsUIStateFlow.test {
+            awaitItem()
+            val stateWithHighlights = awaitItem()
+
+            viewModel.processAction(
+                ViewHighlightsAction.OnDeleteHighlight(stateWithHighlights.highlights.first().id)
+            )
+            val loadingState = awaitItem()
+            assertTrue(loadingState.isLoading)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when delete action succeeds then passes highlight to repository`() = runTest {
+        val viewModel = buildViewModel()
+
+        viewModel.highlightsUIStateFlow.test {
+            awaitItem()
+            val state = awaitItem()
+            viewModel.processAction(
+                ViewHighlightsAction.OnDeleteHighlight(state.highlights.first().id)
+            )
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        advanceUntilIdle()
+        assertEquals("test-highlight-id", fakeHighlightsRepository.deletedHighlightId)
+    }
+
+    @Test
+    fun `when delete action fails then shows error message`() = runTest {
+        fakeHighlightsRepository.shouldDeleteHighlightFromDbThrowException = true
+        val viewModel = buildViewModel()
+
+        viewModel.highlightsUIStateFlow.test {
+            awaitItem()
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        viewModel.effects.test {
+            viewModel.processAction(
+                ViewHighlightsAction.OnDeleteHighlight("test-highlight-id")
+            )
+
+            assertEquals(
+                ViewHighlightsEffect.ShowMessage(R.string.delete_error_message),
+                awaitItem()
+            )
+        }
+    }
+
+    @Test
+    fun `when OnExportHighlights action is processed then sets loading state to true`() = runTest {
+        val viewModel = buildViewModel()
+
+        viewModel.highlightsUIStateFlow.test {
+            awaitItem()
+            awaitItem()
+
+            viewModel.processAction(ViewHighlightsAction.OnExportHighlights(bookId))
 
             val loadingState = awaitItem()
             assertTrue(loadingState.isLoading)
@@ -256,24 +238,25 @@ class ViewHighlightsViewModelTest {
 
     @Test
     fun `when OnExportHighlights action succeeds then emits share effect and clears loading`() = runTest {
+        val viewModel = buildViewModel()
+
         viewModel.effects.test {
-            viewModel.processAction(ViewHighlightsAction.OnExportHighlights("test-book-id"))
+            viewModel.processAction(ViewHighlightsAction.OnExportHighlights(bookId))
             testScheduler.advanceUntilIdle()
 
             val effect = awaitItem()
             assertTrue(effect is ViewHighlightsEffect.ShareHighlights)
             assertNotNull((effect as ViewHighlightsEffect.ShareHighlights).uri)
         }
-
-        assertFalse(viewModel.highlightsUIStateFlow.value.isLoading)
     }
 
     @Test
     fun `when OnExportHighlights action fails then shows error and clears loading`() = runTest {
         fakeBooksRepository.shouldGetBookByIdFromDbThrowException = true
+        val viewModel = buildViewModel()
 
         viewModel.effects.test {
-            viewModel.processAction(ViewHighlightsAction.OnExportHighlights("test-book-id"))
+            viewModel.processAction(ViewHighlightsAction.OnExportHighlights(bookId))
             testScheduler.advanceUntilIdle()
 
             assertEquals(

--- a/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/fakes/FakeHighlightsRepository.kt
+++ b/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/fakes/FakeHighlightsRepository.kt
@@ -11,6 +11,7 @@ class FakeHighlightsRepository : HighlightsRepository {
     var shouldDeleteHighlightFromDbThrowException = false
     var bookIdPassed: String? = null
     var deletedHighlightId: String? = null
+    var getAllHighlightsForBookFromDbInvocationCount = 0
 
     private val fakeHighlight = Highlight(
         id = "test-highlight-id",
@@ -29,6 +30,7 @@ class FakeHighlightsRepository : HighlightsRepository {
 
     override fun getAllHighlightsForBookFromDb(bookId: String): Flow<Result<List<Highlight>>> = flow {
         bookIdPassed = bookId
+        getAllHighlightsForBookFromDbInvocationCount++
         if (shouldGetAllHighlightsForBookFromDbThrowException) {
             emit(Result.failure(RuntimeException("Get all highlights failed")))
         } else {


### PR DESCRIPTION
## Summary

Codebase review §2.1 found one root pattern causing six bugs: ViewModels took nav args (`bookId`, `uri`, `highlightId`) as composable parameters and triggered their initial load from a `LaunchedEffect`. The VM survives rotation, but the composition (and its `LaunchedEffect`s) is destroyed and rebuilt on every rotation, so each rotation re-fires the load against the same long-lived VM instance.

Fix: inject `SavedStateHandle` (auto-populated by `hiltViewModel()` from the nav back-stack entry) and load once — either directly in `init` (`ViewHighlightsViewModel`, `BookInfoViewModel`) or behind a "started" guard on the triggering method (`EditAndSaveHighlightViewModel`). Delete the screen-side `LaunchedEffect` that used to drive each load.

## Bugs fixed

1. **Accumulating infinite collectors** (`ViewHighlightsViewModel`) — moved the `getAllSavedHighlightsUseCase(bookId).collect { }` loop into `init`, removed `getHighlights(bookId)` and its triggering `LaunchedEffect`. The DB flow is now collected exactly once per VM instance regardless of how many times the screen recomposes.
2. **Unsaved edits destroyed on rotation** (`EditAndSaveHighlightViewModel`) — `loadHighlightText` is now guarded (`hasStartedLoadingHighlight`) and only invoked once from `init`; the screen no longer re-triggers it.
3. **OCR re-runs against a deleted file** (`EditAndSaveHighlightViewModel`) — `processImageForHighlightText` is now guarded (`hasStartedProcessingImage`) and driven from `init` via the encoded `uri` nav arg, not a `LaunchedEffect` keyed on `bookId`.
4. **Redundant network refetch** (`BookInfoViewModel`) — `getBookDetail` is now guarded and invoked once from `init` using `bookId` read from `SavedStateHandle`; removed the unused `bookId` screen parameter and updated the one caller in `ProseAppScreen.kt`.
5. **Process-death gaps** — `CaptureAndCropImageViewModel` now persists the capture/crop phase (`CAPTURE`/`CROP`/`DONE`) in `SavedStateHandle` alongside the existing `imageUri`, so process death mid-crop resumes at the crop step instead of relaunching the camera. `EditAndSaveHighlightViewModel` persists the draft `highlightText` (and `savedOnTimestamp`, for edits) in `SavedStateHandle` so an in-progress edit survives process death even after the source image has been deleted.
6. **Composition-correctness bug** (`CaptureAndCropImageScreen`) — wrapped `onImageCaptured(...)` in `LaunchedEffect(screenState)` so a recomposition while already in `ImageCapturedAndCropped` can't navigate twice and duplicate the back stack.

Left untouched per scope: the unkeyed `remember` in `ViewHighlightsScreen.kt` (~line 249) — that's a separate parallel PR.

## Testing

- Test-driven: for each bug, added/rewrote a VM test that reproduces the re-invocation scenario (constructing a fresh VM twice with the same `SavedStateHandle`, or calling the guarded method twice) before applying the guard/init fix.
- New `CaptureAndCropImageViewModelTest.kt` (no prior test existed) covers phase persistence across simulated process death and `onCleared()` cleanup via a real `ViewModelStore`.
- `./gradlew :feature-viewhighlights:testDebugUnitTest :feature-addhighlight:testDebugUnitTest :feature-searchbooks:testDebugUnitTest` — all green (13, 30, 21 tests respectively).
- `./gradlew test` (full suite) and `./gradlew assembleDebug` — both green.
- `docs/architecture.md` and `docs/flows.md` updated for the new SavedStateHandle/one-shot-init convention (per AGENTS.md's "keep docs in sync" rule, since VM constructors changed).

## Gotchas / notes for reviewers

- `EditAndSaveHighlightViewModel` serves two different nav routes (new highlight via `uri`, edit via `highlightId`) through the same class; `init` branches on which nav arg is present in `SavedStateHandle`, and a draft in `SavedStateHandle` short-circuits both branches so a process-death-recreated VM doesn't re-run OCR or re-fetch from the DB.
- One test (`EditAndSaveHighlightViewModelTest`, the uri-auto-init case) needs `mockkStatic(Uri::class)` because `Uri.decode` isn't implemented in this project's unit-test `android.jar` stub (unlike `Uri.parse`, which happens to work); scoped to that single test with `unmockkStatic` cleanup in a `finally`.
- `BookInfoScreen`'s `bookId` parameter was removed entirely (no longer needed by the screen); updated its one call site in `ProseAppScreen.kt`.