### PR TITLE
fix: explicit backup policy for highlights database

### DIFF
--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older that API 31
-   See https://developer.android.com/about/versions/12/backup-restore
--->
+<?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <include domain="database" path="book-db"/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <include domain="database" path="book-db"/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <include domain="database" path="book-db"/>
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
## Summary
`backup_rules.xml` and `data_extraction_rules.xml` were unedited Android Studio templates (all rules commented out, TODOs present), so `allowBackup="true"` was backing up the entire app — including `databases/book-db`, the user's only copy of their highlights — by accident rather than by decision.

## Changes
- `backup_rules.xml`: explicit `<include domain="database" path="book-db"/>` for cloud backup.
- `data_extraction_rules.xml`: explicit `<include domain="database" path="book-db"/>` for both `<cloud-backup>` and `<device-transfer>`.
- Removed template comments/TODOs from both files.

Backup remains enabled (the right call for an app whose entire value is this local DB) — this just makes it an explicit, documented decision instead of an accident. `book-db` matches the actual Room database name in `DatabaseModule.kt`; Room's `-wal`/`-shm` sidecar files are covered by the same path.

## Test plan
- `./gradlew :app:assembleDebug` — passes, manifest/XML parses correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)