### PR TITLE
fix: downsample camera photo decode to avoid OOM on crop entry

### DIFF
--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/ImageRotater.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/ImageRotater.kt
@@ -11,6 +11,8 @@ import timber.log.Timber
 
 internal object ImageRotater {
 
+    internal const val TARGET_LONG_EDGE_PX = 2048
+
     internal fun getRotatedBitmap(context: Context, imageUri: Uri): Bitmap? {
         try {
             val openedinputStream = context.contentResolver.openInputStream(imageUri)
@@ -30,8 +32,22 @@ internal object ImageRotater {
 
                 val matrix = Matrix()
                 if (rotationDegrees != 0) matrix.postRotate(rotationDegrees.toFloat())
+
+                val boundsOptions = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                context.contentResolver.openInputStream(imageUri)?.use {
+                    BitmapFactory.decodeStream(it, null, boundsOptions)
+                }
+
+                val sampleSize = calculateInSampleSize(
+                    sourceWidth = boundsOptions.outWidth,
+                    sourceHeight = boundsOptions.outHeight,
+                    targetSize = TARGET_LONG_EDGE_PX
+                )
+                Timber.d("${this.logTag()}: Downsampling bitmap by factor of $sampleSize")
+
+                val decodeOptions = BitmapFactory.Options().apply { inSampleSize = sampleSize }
                 val bitmap = context.contentResolver.openInputStream(imageUri)
-                    ?.use { BitmapFactory.decodeStream(it) }
+                    ?.use { BitmapFactory.decodeStream(it, null, decodeOptions) }
 
                 if (bitmap == null) {
                     Timber.e("${this.logTag()}: Failed to decode bitmap from URI")
@@ -45,6 +61,15 @@ internal object ImageRotater {
             Timber.e(exception, this.logTag())
             return null
         }
+    }
+
+    internal fun calculateInSampleSize(sourceWidth: Int, sourceHeight: Int, targetSize: Int): Int {
+        var inSampleSize = 1
+        val longEdge = maxOf(sourceWidth, sourceHeight)
+        while (longEdge / inSampleSize > targetSize) {
+            inSampleSize *= 2
+        }
+        return inSampleSize
     }
 
     private fun exifToDegrees(exifOrientation: Int): Int {

--- a/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/ImageRotaterTest.kt
+++ b/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/ImageRotaterTest.kt
@@ -1,0 +1,97 @@
+package com.sriniketh.feature_addhighlight
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImageRotaterTest {
+
+    @Test
+    fun `when source is smaller than target then sample size is 1`() {
+        val sampleSize = ImageRotater.calculateInSampleSize(
+            sourceWidth = 800,
+            sourceHeight = 600,
+            targetSize = ImageRotater.TARGET_LONG_EDGE_PX
+        )
+
+        assertEquals(1, sampleSize)
+    }
+
+    @Test
+    fun `when source equals target then sample size is 1`() {
+        val sampleSize = ImageRotater.calculateInSampleSize(
+            sourceWidth = ImageRotater.TARGET_LONG_EDGE_PX,
+            sourceHeight = ImageRotater.TARGET_LONG_EDGE_PX,
+            targetSize = ImageRotater.TARGET_LONG_EDGE_PX
+        )
+
+        assertEquals(1, sampleSize)
+    }
+
+    @Test
+    fun `when source is a 12 megapixel photo then result is downsampled below target`() {
+        val sourceWidth = 4032
+        val sourceHeight = 3024
+
+        val sampleSize = ImageRotater.calculateInSampleSize(
+            sourceWidth = sourceWidth,
+            sourceHeight = sourceHeight,
+            targetSize = ImageRotater.TARGET_LONG_EDGE_PX
+        )
+
+        assertTrue(sampleSize > 1)
+        assertTrue(sourceWidth / sampleSize <= ImageRotater.TARGET_LONG_EDGE_PX)
+        assertTrue(sourceHeight / sampleSize <= ImageRotater.TARGET_LONG_EDGE_PX)
+    }
+
+    @Test
+    fun `when source is a 108 megapixel photo then result is bounded to target`() {
+        val sourceWidth = 12000
+        val sourceHeight = 9000
+
+        val sampleSize = ImageRotater.calculateInSampleSize(
+            sourceWidth = sourceWidth,
+            sourceHeight = sourceHeight,
+            targetSize = ImageRotater.TARGET_LONG_EDGE_PX
+        )
+
+        val resultingLongEdge = maxOf(sourceWidth, sourceHeight) / sampleSize
+        assertTrue(resultingLongEdge <= ImageRotater.TARGET_LONG_EDGE_PX)
+    }
+
+    @Test
+    fun `when portrait source is larger than target then sample size is based on the long edge`() {
+        val sourceWidth = 3024
+        val sourceHeight = 4032
+
+        val sampleSize = ImageRotater.calculateInSampleSize(
+            sourceWidth = sourceWidth,
+            sourceHeight = sourceHeight,
+            targetSize = ImageRotater.TARGET_LONG_EDGE_PX
+        )
+
+        assertTrue(sourceHeight / sampleSize <= ImageRotater.TARGET_LONG_EDGE_PX)
+    }
+
+    @Test
+    fun `when source dimensions are unknown then sample size defaults to 1`() {
+        val sampleSize = ImageRotater.calculateInSampleSize(
+            sourceWidth = -1,
+            sourceHeight = -1,
+            targetSize = ImageRotater.TARGET_LONG_EDGE_PX
+        )
+
+        assertEquals(1, sampleSize)
+    }
+
+    @Test
+    fun `sample size is always a power of two`() {
+        val sampleSize = ImageRotater.calculateInSampleSize(
+            sourceWidth = 12000,
+            sourceHeight = 9000,
+            targetSize = ImageRotater.TARGET_LONG_EDGE_PX
+        )
+
+        assertEquals(0, sampleSize and (sampleSize - 1))
+    }
+}


### PR DESCRIPTION
## Summary
`ImageRotater` decoded the full-resolution camera JPEG with no downsampling (~48MB as ARGB_8888 for a 12MP photo, more on higher-MP sensors), then allocated a second full-size bitmap copy to apply EXIF rotation — a plausible OOM on entry to the crop screen.

## Fix
Unified `BitmapFactory.Options.inSampleSize`-based downsampling for all API levels (minSdk 26, no version branching). Two-pass decode: bounds-only pass to read source dimensions, then a real decode with `inSampleSize` computed to cap the long edge at `TARGET_LONG_EDGE_PX = 2048`. EXIF rotation applied as before to the now-downsampled bitmap. Rejected an `ImageDecoder.setTargetSize` (API 28+)-only approach since it would require a dual-path implementation (new path + the existing manual-rotation fallback for API 26-27) for marginal benefit.

The crop screen's output (fed back into the same URI) is what ML Kit later OCRs, so this bitmap resolution flows through to both cropping UI and OCR input — there's no separate full-res path retained anywhere in the pipeline.

## Test plan
- Added `ImageRotaterTest.kt` (7 cases) unit-testing the extracted pure `calculateInSampleSize` function: below-target passthrough, exact-target passthrough, realistic 12MP source, 108MP-scale source, portrait orientation, defensive negative-dimension default, power-of-two invariant.
- `./gradlew :feature-addhighlight:testDebugUnitTest` — full module suite green.

## Known tradeoff
OCR input is now capped at 2048px long edge instead of full sensor resolution. 2048px is generally ample for printed-text OCR, but this is an unverified product tradeoff worth watching — if OCR accuracy regresses on dense/small-font pages, the target size is the first thing to revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)