### PR TITLE
fix: replace lambda in BookInfoUiState with VM method

### DIFF
--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoScreen.kt
@@ -93,7 +93,8 @@ fun BookInfoScreen(
         modifier = modifier,
         uiState = uiState,
         snackbarHostState = snackbarHostState,
-        goBack = { goBack() }
+        goBack = { goBack() },
+        onAddToShelf = { viewModel.addBookToShelf() }
     )
 }
 
@@ -103,7 +104,8 @@ internal fun BookInfo(
     uiState: BookInfoUiState,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     modifier: Modifier = Modifier,
-    goBack: () -> Unit
+    goBack: () -> Unit,
+    onAddToShelf: () -> Unit = {}
 ) {
     val scrollBehavior = run { TopAppBarDefaults.exitUntilCollapsedScrollBehavior() }.let { remember { it } }
     Scaffold(
@@ -119,7 +121,7 @@ internal fun BookInfo(
         },
         floatingActionButton = {
             if (uiState.canAddToShelf) {
-                BookInfoScreenFloatingActionButton(uiState.addBookToShelf)
+                BookInfoScreenFloatingActionButton(onAddToShelf)
             }
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
@@ -322,8 +324,7 @@ internal fun BookInfoScreenPreview() {
                     averageRating = 4.3,
                     ratingsCount = 1227
                 ),
-                canAddToShelf = true,
-                addBookToShelf = {}
+                canAddToShelf = true
             ),
             goBack = {}
         )

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/BookInfoViewModel.kt
@@ -35,6 +35,8 @@ class BookInfoViewModel @Inject constructor(
     private val _effects = Channel<BookInfoEffect>(Channel.BUFFERED)
     internal val effects: Flow<BookInfoEffect> = _effects.receiveAsFlow()
 
+    private var currentBook: Book? = null
+
     fun getBookDetail(volumeId: String) {
         viewModelScope.launch {
             _uiState.update { state ->
@@ -43,13 +45,13 @@ class BookInfoViewModel @Inject constructor(
             val result = fetchBookInfoUseCase(volumeId)
             if (result.isSuccess) {
                 val book = result.getOrThrow()
+                currentBook = book
                 val isInDb = isBookInDbUseCase(book)
                 _uiState.update { state ->
                     state.copy(
                         isLoading = false,
                         book = book.asUiData(),
-                        canAddToShelf = !isInDb,
-                        addBookToShelf = { addBookToShelf(book) }
+                        canAddToShelf = !isInDb
                     )
                 }
             } else if (result.isFailure) {
@@ -61,7 +63,8 @@ class BookInfoViewModel @Inject constructor(
         }
     }
 
-    private fun addBookToShelf(book: Book) {
+    fun addBookToShelf() {
+        val book = currentBook ?: return
         viewModelScope.launch {
             _uiState.update { state ->
                 state.copy(isLoading = true)
@@ -100,8 +103,7 @@ class BookInfoViewModel @Inject constructor(
 data class BookInfoUiState(
     val isLoading: Boolean = false,
     val book: BookInfoUiData? = null,
-    val canAddToShelf: Boolean = false,
-    val addBookToShelf: () -> Unit = {}
+    val canAddToShelf: Boolean = false
 )
 
 data class BookInfoUiData(

--- a/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/BookInfoViewModelTest.kt
+++ b/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/BookInfoViewModelTest.kt
@@ -138,7 +138,7 @@ class BookInfoViewModelTest {
         assertNotNull(currentState.book)
         assertTrue(currentState.canAddToShelf)
 
-        currentState.addBookToShelf()
+        viewModel.addBookToShelf()
         advanceUntilIdle()
 
         assertNotNull(fakeBooksRepository.insertedBook)
@@ -155,7 +155,7 @@ class BookInfoViewModelTest {
         val beforeAddState = viewModel.uiState.value
         assertTrue(beforeAddState.canAddToShelf)
 
-        beforeAddState.addBookToShelf()
+        viewModel.addBookToShelf()
         advanceUntilIdle()
 
         val afterAddState = viewModel.uiState.value
@@ -169,10 +169,8 @@ class BookInfoViewModelTest {
         viewModel.getBookDetail("test-volume-id")
         advanceUntilIdle()
 
-        val addToShelf = viewModel.uiState.value.addBookToShelf
-
         viewModel.effects.test {
-            addToShelf()
+            viewModel.addBookToShelf()
 
             assertEquals(
                 BookInfoEffect.NavigateToBookshelf,


### PR DESCRIPTION
## Summary
`BookInfoUiState.addBookToShelf: () -> Unit` stored a lambda directly in UI state — lambda identity equality defeats StateFlow conflation and Compose recomposition skipping, and smuggles the captured `Book` through state instead of holding it in the VM.

## Fix
Removed the lambda from `BookInfoUiState`; the `Book` is now held privately in `BookInfoViewModel` (`currentBook`, kept in sync on every successful load) and exposed via a public `fun addBookToShelf()` that the screen calls directly. `canAddToShelf: Boolean` already existed in state alongside the old lambda and needed no changes — it already correctly gates FAB visibility.

## Test plan
- Updated `BookInfoViewModelTest.kt` to call `viewModel.addBookToShelf()` directly instead of reading the lambda off state.
- `./gradlew :feature-searchbooks:testDebugUnitTest` — all 9 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)