### PR TITLE
fix: sanitize export filename, close path-traversal guard bypass

### DIFF
--- a/app/src/main/java/com/sriniketh/prose/files/FileSourceImpl.kt
+++ b/app/src/main/java/com/sriniketh/prose/files/FileSourceImpl.kt
@@ -16,11 +16,7 @@ class FileSourceImpl @Inject constructor(
 
     override fun createNewFile(fileName: String): Uri {
         val newFile = File(appContext.cacheDir, fileName)
-        val resolvedPath = newFile.canonicalPath
-        val cacheDirPath = appContext.cacheDir.canonicalPath
-        if (!resolvedPath.startsWith(cacheDirPath)) {
-            throw SecurityException("File path $fileName escapes cache directory")
-        }
+        newFile.assertWithinCacheDir(appContext.cacheDir, fileName)
         val contentUri = getFileProviderUri(newFile)
         Timber.d("${this.logTag()}: Created file $contentUri")
         return contentUri
@@ -28,11 +24,7 @@ class FileSourceImpl @Inject constructor(
 
     override fun writeToFile(fileName: String, content: String): Uri {
         val file = File(appContext.cacheDir, fileName)
-        val resolvedPath = file.canonicalPath
-        val cacheDirPath = appContext.cacheDir.canonicalPath
-        if (!resolvedPath.startsWith(cacheDirPath)) {
-            throw SecurityException("File path $fileName escapes cache directory")
-        }
+        file.assertWithinCacheDir(appContext.cacheDir, fileName)
         file.writeText(content)
         val contentUri = getFileProviderUri(file)
         Timber.d("${this.logTag()}: Wrote file $contentUri")
@@ -48,5 +40,15 @@ class FileSourceImpl @Inject constructor(
     private fun getFileProviderUri(file: File): Uri {
         val authority = "${appContext.packageName}.fileProvider"
         return getUriForFile(appContext, authority, file)
+    }
+
+    private fun File.assertWithinCacheDir(cacheDir: File, fileName: String) {
+        val resolvedPath = canonicalPath
+        val cacheDirPath = cacheDir.canonicalPath
+        val isWithinCacheDir = resolvedPath == cacheDirPath ||
+            resolvedPath.startsWith(cacheDirPath + File.separator)
+        if (!isWithinCacheDir) {
+            throw SecurityException("File path $fileName escapes cache directory")
+        }
     }
 }

--- a/app/src/main/java/com/sriniketh/prose/files/FileSourceImpl.kt
+++ b/app/src/main/java/com/sriniketh/prose/files/FileSourceImpl.kt
@@ -16,6 +16,11 @@ class FileSourceImpl @Inject constructor(
 
     override fun createNewFile(fileName: String): Uri {
         val newFile = File(appContext.cacheDir, fileName)
+        val resolvedPath = newFile.canonicalPath
+        val cacheDirPath = appContext.cacheDir.canonicalPath
+        if (!resolvedPath.startsWith(cacheDirPath)) {
+            throw SecurityException("File path $fileName escapes cache directory")
+        }
         val contentUri = getFileProviderUri(newFile)
         Timber.d("${this.logTag()}: Created file $contentUri")
         return contentUri
@@ -23,6 +28,11 @@ class FileSourceImpl @Inject constructor(
 
     override fun writeToFile(fileName: String, content: String): Uri {
         val file = File(appContext.cacheDir, fileName)
+        val resolvedPath = file.canonicalPath
+        val cacheDirPath = appContext.cacheDir.canonicalPath
+        if (!resolvedPath.startsWith(cacheDirPath)) {
+            throw SecurityException("File path $fileName escapes cache directory")
+        }
         file.writeText(content)
         val contentUri = getFileProviderUri(file)
         Timber.d("${this.logTag()}: Wrote file $contentUri")

--- a/core-data/src/main/java/com/sriniketh/core_data/usecases/ExportHighlightsUseCase.kt
+++ b/core-data/src/main/java/com/sriniketh/core_data/usecases/ExportHighlightsUseCase.kt
@@ -55,7 +55,10 @@ class ExportHighlightsUseCase @Inject constructor(
 
         val json = exportJson.encodeToString(export)
 
-        val fileName = "${book.info.title.lowercase().replace(" ", "_")}_export.json"
+        val sanitizedTitle = book.info.title
+            .lowercase()
+            .replace(Regex("[^a-z0-9_-]"), "_")
+        val fileName = "${sanitizedTitle}_export.json"
         val uri = fileSource.writeToFile(fileName, json)
         Result.success(uri)
     } catch (exception: Exception) {

--- a/core-data/src/test/java/com/sriniketh/core_data/usecases/ExportHighlightsUseCaseTest.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/usecases/ExportHighlightsUseCaseTest.kt
@@ -106,4 +106,75 @@ class ExportHighlightsUseCaseTest {
         assertFalse(writtenContent.contains("\"publisher\""))
         assertFalse(writtenContent.contains("\"subtitle\""))
     }
+
+    @Test
+    fun `when book title contains path traversal sequence then filename is sanitized`() = runTest {
+        fakeBooksRepository.fakeBookToReturn = Book(
+            id = "test-id",
+            info = BookInfo(
+                title = "Book../Escape",
+                subtitle = null,
+                authors = listOf("Test Author"),
+                thumbnailLink = null,
+                publisher = null,
+                publishedDate = null,
+                description = null,
+                pageCount = null,
+                averageRating = null,
+                ratingsCount = null
+            )
+        )
+        useCase("test-book-id")
+        val fileName = fakeFileSource.lastWrittenFileName!!
+        assertFalse(fileName.contains(".."))
+        assertTrue(fileName.contains("_export.json"))
+        assertFalse(fileName.contains("/"))
+    }
+
+    @Test
+    fun `when book title contains forward slash then filename is sanitized`() = runTest {
+        fakeBooksRepository.fakeBookToReturn = Book(
+            id = "test-id",
+            info = BookInfo(
+                title = "TCP/IP Illustrated",
+                subtitle = null,
+                authors = listOf("Test Author"),
+                thumbnailLink = null,
+                publisher = null,
+                publishedDate = null,
+                description = null,
+                pageCount = null,
+                averageRating = null,
+                ratingsCount = null
+            )
+        )
+        val result = useCase("test-book-id")
+        assertTrue(result.isSuccess)
+        val fileName = fakeFileSource.lastWrittenFileName!!
+        assertFalse(fileName.contains("/"))
+        assertTrue(fileName.contains("_export.json"))
+    }
+
+    @Test
+    fun `when book title contains special characters then filename is sanitized to alphanumeric underscore dash only`() = runTest {
+        fakeBooksRepository.fakeBookToReturn = Book(
+            id = "test-id",
+            info = BookInfo(
+                title = "Book@#$%^&*()={}/\\:;'\"<>?|",
+                subtitle = null,
+                authors = listOf("Test Author"),
+                thumbnailLink = null,
+                publisher = null,
+                publishedDate = null,
+                description = null,
+                pageCount = null,
+                averageRating = null,
+                ratingsCount = null
+            )
+        )
+        val result = useCase("test-book-id")
+        assertTrue(result.isSuccess)
+        val fileName = fakeFileSource.lastWrittenFileName!!
+        assertTrue(fileName.matches(Regex("^[a-z0-9_-]+_export\\.json$")))
+    }
 }


### PR DESCRIPTION
## Summary
`ExportHighlightsUseCase` built the export filename from the network-derived book title, replacing only spaces — a title containing `../` could write outside the intended cache directory, and a plain `/` (e.g. "TCP/IP Illustrated") crashed the export with `FileNotFoundException`.

## Fix
Two layers, as recommended by the review:
1. **Filename sanitization**: whitelist regex (`[^a-z0-9_-]` → `_`) in `ExportHighlightsUseCase`.
2. **Defense in depth**: `FileSourceImpl.createNewFile`/`writeToFile` now reject any resolved path whose canonical path isn't under `cacheDir`, via a shared `File.assertWithinCacheDir()` helper. This guard was corrected during review — an initial version used a bare `startsWith(cacheDirPath)` check, which is bypassable by a sibling directory (e.g. `cache_backup/evil.json` string-prefix-matches `cache`); it now requires an exact match or a trailing separator.

## Test plan
- `ExportHighlightsUseCaseTest`: 3 new cases — `../` in title, plain `/` in title, broader special-character sweep — asserting the actual resulting filename, not just "doesn't throw".
- `./gradlew :core-data:test` — all 10 tests pass.
- `./gradlew :app:compileDebugKotlin` — the `app` module has no JVM test source set, so the canonical-path guard itself has no automated test coverage (would require introducing Robolectric to this module); accepted as a known gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)