### PR TITLE
fix: add persistent error state + retry to bookshelf and search

### DIFF
--- a/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
+++ b/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
@@ -200,6 +200,45 @@ class BookshelfScreenTest {
         composeTestRule.onNodeWithText("Test Book Title").assertDoesNotExist()
     }
 
+    @Test
+    fun whenErrorMessageIsSetThenErrorStateAndRetryButtonAreDisplayed() {
+        val uiState = BookshelfUIState(errorMessage = R.string.getallbooks_error_message)
+
+        composeTestRule.setContent {
+            AppTheme {
+                Bookshelf(
+                    uiState = uiState,
+                    goToSearch = {},
+                    goToHighlight = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("BookshelfErrorState").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("BookshelfRetryButton").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Go ahead, grab a book!").assertDoesNotExist()
+    }
+
+    @Test
+    fun whenRetryButtonIsClickedThenOnRetryIsCalled() {
+        val uiState = BookshelfUIState(errorMessage = R.string.getallbooks_error_message)
+        var onRetryCalled = false
+
+        composeTestRule.setContent {
+            AppTheme {
+                Bookshelf(
+                    uiState = uiState,
+                    goToSearch = {},
+                    goToHighlight = {},
+                    onRetry = { onRetryCalled = true }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("BookshelfRetryButton").performClick()
+        assertTrue(onRetryCalled)
+    }
+
     private fun createTestBookUIState(
         id: String = "test-id",
         title: String = "Test Title",

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -85,7 +86,8 @@ fun BookshelfScreen(
         snackbarHostState = snackbarHostState,
         modifier = modifier,
         goToSearch = { goToSearch() },
-        goToHighlight = { goToHighlight(it) }
+        goToHighlight = { goToHighlight(it) },
+        onRetry = { viewModel.retryLoadBooks() }
     )
 }
 
@@ -96,7 +98,8 @@ internal fun Bookshelf(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     modifier: Modifier = Modifier,
     goToSearch: () -> Unit,
-    goToHighlight: (String) -> Unit
+    goToHighlight: (String) -> Unit,
+    onRetry: () -> Unit = {}
 ) {
     val scrollBehavior = run { TopAppBarDefaults.exitUntilCollapsedScrollBehavior() }.let { remember { it } }
     Scaffold(
@@ -137,7 +140,31 @@ internal fun Bookshelf(
             )
         }
 
-        if (uiState.books.isEmpty() && !uiState.isLoading) {
+        if (uiState.errorMessage != null && !uiState.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .testTag("BookshelfErrorState")
+            ) {
+                Column(
+                    modifier = Modifier.align(Alignment.Center),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = stringResource(id = uiState.errorMessage),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                    Button(
+                        modifier = Modifier
+                            .padding(top = 12.dp)
+                            .testTag("BookshelfRetryButton"),
+                        onClick = onRetry
+                    ) {
+                        Text(text = stringResource(id = R.string.bookshelf_retry_button))
+                    }
+                }
+            }
+        } else if (uiState.books.isEmpty() && !uiState.isLoading) {
             Box(
                 modifier = Modifier.fillMaxSize()
             ) {
@@ -273,6 +300,16 @@ internal fun BookshelfScreenSuccessNoBooksPreview() {
     AppTheme {
         Bookshelf(
             uiState = BookshelfUIState(books = persistentListOf()),
+            goToSearch = {}, goToHighlight = {})
+    }
+}
+
+@PreviewLightDark
+@Composable
+internal fun BookshelfScreenErrorPreview() {
+    AppTheme {
+        Bookshelf(
+            uiState = BookshelfUIState(errorMessage = R.string.getallbooks_error_message),
             goToSearch = {}, goToHighlight = {})
     }
 }

--- a/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfViewModel.kt
+++ b/feature-bookshelf/src/main/java/com/sriniketh/feature_bookshelf/BookshelfViewModel.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,6 +36,8 @@ class BookshelfViewModel @Inject constructor(
     private val _effects = Channel<BookshelfEffect>(Channel.BUFFERED)
     internal val effects: Flow<BookshelfEffect> = _effects.receiveAsFlow()
 
+    private var loadBooksJob: Job? = null
+
     init {
         viewModelScope.launch {
             savedStateHandle.getStateFlow(BOOKSHELF_SHOW_ADDED_MESSAGE, false)
@@ -45,9 +48,18 @@ class BookshelfViewModel @Inject constructor(
                     }
                 }
         }
-        viewModelScope.launch {
+        loadBooks()
+    }
+
+    fun retryLoadBooks() {
+        loadBooks()
+    }
+
+    private fun loadBooks() {
+        loadBooksJob?.cancel()
+        loadBooksJob = viewModelScope.launch {
             _bookshelfUIState.update { state ->
-                state.copy(isLoading = true)
+                state.copy(isLoading = true, errorMessage = null)
             }
             getAllSavedBooksUseCase().collect { result ->
                 if (result.isSuccess) {
@@ -55,12 +67,16 @@ class BookshelfViewModel @Inject constructor(
                     _bookshelfUIState.update { state ->
                         state.copy(
                             isLoading = false,
+                            errorMessage = null,
                             books = books.map { it.asBookshelfUIState() }.toImmutableList()
                         )
                     }
                 } else if (result.isFailure) {
                     _bookshelfUIState.update { state ->
-                        state.copy(isLoading = false)
+                        state.copy(
+                            isLoading = false,
+                            errorMessage = R.string.getallbooks_error_message
+                        )
                     }
                     _effects.trySend(BookshelfEffect.ShowMessage(R.string.getallbooks_error_message))
                 }
@@ -78,6 +94,7 @@ class BookshelfViewModel @Inject constructor(
 
 internal data class BookshelfUIState(
     val isLoading: Boolean = false,
+    @StringRes val errorMessage: Int? = null,
     val books: ImmutableList<BookUIState> = persistentListOf()
 )
 

--- a/feature-bookshelf/src/main/res/values/strings.xml
+++ b/feature-bookshelf/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="bookshelf_pagetitle">Bookshelf</string>
     <string name="bookshelf_empty_text">Go ahead, grab a book!</string>
     <string name="getallbooks_error_message">Error retrieving saved books.</string>
+    <string name="bookshelf_retry_button">Retry</string>
     <string name="search_fab_cont_desc">search for a book button</string>
     <string name="book_added_to_shelf_message">Book has been added to shelf!</string>
 </resources>

--- a/feature-bookshelf/src/test/java/com/sriniketh/feature_bookshelf/BookshelfViewModelTest.kt
+++ b/feature-bookshelf/src/test/java/com/sriniketh/feature_bookshelf/BookshelfViewModelTest.kt
@@ -15,6 +15,7 @@ import kotlinx.collections.immutable.persistentListOf
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -102,6 +103,39 @@ class BookshelfViewModelTest {
         val finalState = failingViewModel.bookshelfUIState.value
         assertFalse(finalState.isLoading)
         assertTrue(finalState.books.isEmpty())
+    }
+
+    @Test
+    fun `when loading fails then error message is set in state`() = runTest {
+        fakeBooksRepository.shouldGetAllSavedBooksFromDbThrowException = true
+        val failingViewModel = BookshelfViewModel(GetAllSavedBooksUseCase(fakeBooksRepository), SavedStateHandle())
+
+        advanceUntilIdle()
+
+        val finalState = failingViewModel.bookshelfUIState.value
+        assertFalse(finalState.isLoading)
+        assertTrue(finalState.books.isEmpty())
+        assertEquals(R.string.getallbooks_error_message, finalState.errorMessage)
+    }
+
+    @Test
+    fun `when retry is invoked after a failure then books load and error clears`() = runTest {
+        fakeBooksRepository.shouldGetAllSavedBooksFromDbThrowException = true
+        val failingViewModel = BookshelfViewModel(GetAllSavedBooksUseCase(fakeBooksRepository), SavedStateHandle())
+        advanceUntilIdle()
+        assertEquals(
+            R.string.getallbooks_error_message,
+            failingViewModel.bookshelfUIState.value.errorMessage
+        )
+
+        fakeBooksRepository.shouldGetAllSavedBooksFromDbThrowException = false
+        failingViewModel.retryLoadBooks()
+        advanceUntilIdle()
+
+        val finalState = failingViewModel.bookshelfUIState.value
+        assertFalse(finalState.isLoading)
+        assertNull(finalState.errorMessage)
+        assertEquals(1, finalState.books.size)
     }
 
     @Test

--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
@@ -279,6 +279,48 @@ class SearchBookScreenTest {
         composeTestRule.onNodeWithText("New Top Book 0").assertIsDisplayed()
     }
 
+    @Test
+    fun whenErrorMessageIsSetThenErrorStateAndRetryButtonAreDisplayed() {
+        val uiState = BookSearchUiState(errorMessage = R.string.search_error_message)
+
+        composeTestRule.setContent {
+            AppTheme {
+                SearchBook(
+                    uiState = uiState,
+                    searchForBooks = {},
+                    navigateToBookInfo = {},
+                    resetSearch = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
+        composeTestRule.onNodeWithTag("SearchErrorState").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("SearchRetryButton").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenRetryButtonIsClickedThenOnRetryIsCalled() {
+        val uiState = BookSearchUiState(errorMessage = R.string.search_error_message)
+        var onRetryCalled = false
+
+        composeTestRule.setContent {
+            AppTheme {
+                SearchBook(
+                    uiState = uiState,
+                    searchForBooks = {},
+                    navigateToBookInfo = {},
+                    resetSearch = {},
+                    onRetry = { onRetryCalled = true }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
+        composeTestRule.onNodeWithTag("SearchRetryButton").performClick()
+        assertTrue(onRetryCalled)
+    }
+
     private fun createTestBookUiState(
         id: String = "test-id",
         title: String = "Test Title",

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -94,6 +95,9 @@ fun SearchBookScreen(
         },
         resetSearch = {
             viewModel.resetSearch()
+        },
+        onRetry = {
+            viewModel.retrySearch()
         }
     )
 }
@@ -106,7 +110,8 @@ internal fun SearchBook(
     modifier: Modifier = Modifier,
     searchForBooks: (String) -> Unit,
     navigateToBookInfo: (String) -> Unit,
-    resetSearch: () -> Unit
+    resetSearch: () -> Unit,
+    onRetry: () -> Unit = {}
 ) {
     val focusRequester = remember { FocusRequester() }
     var text by rememberSaveable { mutableStateOf("") }
@@ -184,6 +189,28 @@ internal fun SearchBook(
                         .fillMaxWidth()
                         .testTag("SearchBookLoadingIndicator")
                 )
+            }
+            if (uiState.errorMessage != null && !uiState.isLoading) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp)
+                        .testTag("SearchErrorState"),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = stringResource(id = uiState.errorMessage),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                    Button(
+                        modifier = Modifier
+                            .padding(top = 12.dp)
+                            .testTag("SearchRetryButton"),
+                        onClick = onRetry
+                    ) {
+                        Text(text = stringResource(id = R.string.search_retry_button))
+                    }
+                }
             }
             LazyColumn(
                 state = listState,
@@ -269,6 +296,21 @@ internal fun SearchBookScreenPreview() {
                         )
                     )
                 ),
+                searchForBooks = {},
+                navigateToBookInfo = {},
+                resetSearch = {}
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+internal fun SearchBookScreenErrorPreview() {
+    AppTheme {
+        Surface {
+            SearchBook(
+                uiState = BookSearchUiState(errorMessage = R.string.search_error_message),
                 searchForBooks = {},
                 navigateToBookInfo = {},
                 resetSearch = {}

--- a/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookViewModel.kt
+++ b/feature-searchbooks/src/main/java/com/sriniketh/feature_searchbooks/SearchBookViewModel.kt
@@ -44,6 +44,8 @@ class SearchBookViewModel @Inject constructor(
 
     private val queryFlow: MutableStateFlow<String> = MutableStateFlow("")
     private val resetChannel: Channel<Unit> = Channel(Channel.CONFLATED)
+    private val retryChannel: Channel<String> = Channel(Channel.CONFLATED)
+    private var lastSearchedQuery: String? = null
 
     init {
         val searches: Flow<SearchAction> = queryFlow
@@ -51,8 +53,9 @@ class SearchBookViewModel @Inject constructor(
             .debounce(DEBOUNCE_MILLIS)
             .distinctUntilChanged()
             .map { query -> SearchAction.Search(query) }
+        val retries: Flow<SearchAction> = retryChannel.receiveAsFlow().map { query -> SearchAction.Search(query) }
         val resets: Flow<SearchAction> = resetChannel.receiveAsFlow().map { SearchAction.Clear }
-        merge(searches, resets)
+        merge(searches, retries, resets)
             .flatMapLatest { action ->
                 when (action) {
                     is SearchAction.Search -> searchResultsFlow(action.query)
@@ -71,8 +74,13 @@ class SearchBookViewModel @Inject constructor(
         resetChannel.trySend(Unit)
     }
 
+    fun retrySearch() {
+        lastSearchedQuery?.let { query -> retryChannel.trySend(query) }
+    }
+
     private fun searchResultsFlow(query: String): Flow<BookSearchUiState> = flow {
-        emit(_searchUiState.value.copy(isLoading = true))
+        lastSearchedQuery = query
+        emit(_searchUiState.value.copy(isLoading = true, errorMessage = null))
         val result = searchForBookUseCase(query)
         if (result.isSuccess) {
             emit(
@@ -82,7 +90,7 @@ class SearchBookViewModel @Inject constructor(
                 )
             )
         } else {
-            emit(_searchUiState.value.copy(isLoading = false))
+            emit(_searchUiState.value.copy(isLoading = false, errorMessage = R.string.search_error_message))
             _effects.trySend(SearchBookEffect.ShowMessage(R.string.search_error_message))
         }
     }
@@ -108,6 +116,7 @@ class SearchBookViewModel @Inject constructor(
 
 internal data class BookSearchUiState(
     val isLoading: Boolean = false,
+    @StringRes val errorMessage: Int? = null,
     val bookUiStates: ImmutableList<BookUiState> = persistentListOf()
 )
 

--- a/feature-searchbooks/src/main/res/values/strings.xml
+++ b/feature-searchbooks/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="search_icon_cont_desc">Search icon</string>
     <string name="close_icon_cont_desc">Close icon</string>
     <string name="search_error_message">Error searching for book. Please try again.</string>
+    <string name="search_retry_button">Retry</string>
 
     <string name="add_to_shelf_button_text">Add to shelf</string>
     <string name="book_info_load_error_message">Error loading book details.</string>

--- a/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/SearchBookViewModelTest.kt
+++ b/feature-searchbooks/src/test/java/com/sriniketh/feature_searchbooks/SearchBookViewModelTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -90,6 +91,39 @@ class SearchBookViewModelTest {
         }
 
         assertFalse(viewModel.searchUiState.value.isLoading)
+    }
+
+    @Test
+    fun `when search for book fails then error message is set in state and results stay empty`() = runTest {
+        fakeBooksRepository.shouldSearchForBooksThrowException = true
+
+        viewModel.searchForBook("test query")
+        advanceUntilIdle()
+
+        val state = viewModel.searchUiState.value
+        assertFalse(state.isLoading)
+        assertTrue(state.bookUiStates.isEmpty())
+        assertEquals(R.string.search_error_message, state.errorMessage)
+    }
+
+    @Test
+    fun `when retry is invoked after a failure then the identical query searches again and succeeds`() = runTest {
+        fakeBooksRepository.shouldSearchForBooksThrowException = true
+
+        viewModel.searchForBook("the hobbit")
+        advanceUntilIdle()
+        assertEquals(listOf("the hobbit"), fakeBooksRepository.queriesSearched)
+        assertEquals(R.string.search_error_message, viewModel.searchUiState.value.errorMessage)
+
+        fakeBooksRepository.shouldSearchForBooksThrowException = false
+        viewModel.retrySearch()
+        advanceUntilIdle()
+
+        assertEquals(listOf("the hobbit", "the hobbit"), fakeBooksRepository.queriesSearched)
+        val state = viewModel.searchUiState.value
+        assertNull(state.errorMessage)
+        assertFalse(state.isLoading)
+        assertEquals(1, state.bookUiStates.size)
     }
 
     @Test


### PR DESCRIPTION
## Summary
UI states modeled only `isLoading` + data — no persistent error slot. A failed bookshelf load showed a transient snackbar then fell through to the "empty bookshelf" placeholder, falsely telling the user they have zero books when the DB errored. The search architecture's `distinctUntilChanged`/conflation actively prevented retrying an identical query after a failure.

## Fix
Added `@StringRes val errorMessage: Int? = null` to `BookshelfUIState` and `BookSearchUiState` — distinct from `isLoading` and "no results" — with the existing `ShowMessage` snackbar effect retained.

- **Bookshelf**: extracted `loadBooks()` (cancels any prior job before relaunching — avoids reintroducing a duplicate-collector bug), sets/clears `errorMessage`, added `retryLoadBooks()`. Screen renders error branch before the empty-placeholder branch.
- **Search**: added a `retryChannel: Channel<String>(CONFLATED)` merged as a third source into the existing `merge(...).flatMapLatest{...}` pipeline alongside the debounced query flow — this bypasses `distinctUntilChanged` on retry without touching the debounce/stale-response-cancellation path the rest of the suite depends on. `retrySearch()` resends the last-searched query through this channel.

Scoped to bookshelf + search only, per the finding — `BookInfoUiState`, `ViewHighlightsViewModel`, and navigation are untouched (handled elsewhere).

## Test plan
- `SearchBookViewModelTest`: all 14 cases pass (12 original debounce/race tests + 2 new), confirming the debounce/stale-response/reset race suite is not regressed.
- `BookshelfViewModelTest`: all 8 cases pass (6 original + 2 new).
- `./gradlew :feature-bookshelf:testDebugUnitTest :feature-searchbooks:testDebugUnitTest` green; androidTest sources compile.
- Connected/instrumented UI tests were not run (no emulator attached in the dev environment) — compiled but unexecuted.

## Note
`docs/architecture.md`'s error-handling section still describes a single-mechanism convention (`ShowMessage` effect only); it's now mildly incomplete since 2 of 4 VMs also carry a persistent error+retry slot. Left as-is since this is a partial rollout and other in-flight PRs touch the same doc region — worth a follow-up doc pass once the convention is uniformly adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)