### PR TITLE
fix: rethrow CancellationException in repositories and use cases

### DIFF
--- a/core-data/src/main/java/com/sriniketh/core_data/BooksRepositoryImpl.kt
+++ b/core-data/src/main/java/com/sriniketh/core_data/BooksRepositoryImpl.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 
 class BooksRepositoryImpl @Inject constructor(
 	private val remoteBookDataSource: BooksRemoteDataSource,
@@ -23,6 +24,8 @@ class BooksRepositoryImpl @Inject constructor(
 		try {
 			val books = remoteBookDataSource.getVolumes(searchQuery).asBookSearchResult()
 			Result.success(books)
+		} catch (cancellationException: CancellationException) {
+			throw cancellationException
 		} catch (exception: Exception) {
 			Timber.e(exception, this.logTag())
 			Result.failure(exception)
@@ -32,6 +35,8 @@ class BooksRepositoryImpl @Inject constructor(
 		try {
 			val book = remoteBookDataSource.getVolume(volumeId).asBook()
 			Result.success(book)
+		} catch (cancellationException: CancellationException) {
+			throw cancellationException
 		} catch (exception: Exception) {
 			Timber.e(exception, this.logTag())
 			Result.failure(exception)
@@ -41,6 +46,8 @@ class BooksRepositoryImpl @Inject constructor(
 		try {
 			localBookDataSource.insertBook(book.asBookEntity())
 			Result.success(Unit)
+		} catch (cancellationException: CancellationException) {
+			throw cancellationException
 		} catch (exception: Exception) {
 			Timber.e(exception, this.logTag())
 			Result.failure(exception)
@@ -49,6 +56,8 @@ class BooksRepositoryImpl @Inject constructor(
 	override suspend fun doesBookExistInDb(bookId: String): Boolean =
 		try {
 			localBookDataSource.doesBookExist(bookId)
+		} catch (cancellationException: CancellationException) {
+			throw cancellationException
 		} catch (exception: Exception) {
 			Timber.e(exception, this.logTag())
 			false
@@ -72,6 +81,8 @@ class BooksRepositoryImpl @Inject constructor(
 			} else {
 				Result.failure(NoSuchElementException("Book not found: $bookId"))
 			}
+		} catch (cancellationException: CancellationException) {
+			throw cancellationException
 		} catch (exception: Exception) {
 			Timber.e(exception, this.logTag())
 			Result.failure(exception)
@@ -81,6 +92,8 @@ class BooksRepositoryImpl @Inject constructor(
 		try {
 			localBookDataSource.deleteBook(book.asBookEntity())
 			Result.success(Unit)
+		} catch (cancellationException: CancellationException) {
+			throw cancellationException
 		} catch (exception: Exception) {
 			Timber.e(exception, this.logTag())
 			Result.failure(exception)

--- a/core-data/src/main/java/com/sriniketh/core_data/HighlightsRepositoryImpl.kt
+++ b/core-data/src/main/java/com/sriniketh/core_data/HighlightsRepositoryImpl.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 
 class HighlightsRepositoryImpl @Inject constructor(
     private val localHighlightsDataSource: HighlightDao
@@ -18,6 +19,8 @@ class HighlightsRepositoryImpl @Inject constructor(
         try {
             localHighlightsDataSource.insertHighlight(highlight.asHighlightEntity())
             Result.success(Unit)
+        } catch (cancellationException: CancellationException) {
+            throw cancellationException
         } catch (exception: Exception) {
             Timber.e(exception)
             Result.failure(exception)
@@ -31,6 +34,8 @@ class HighlightsRepositoryImpl @Inject constructor(
             } else {
                 Result.failure(NoSuchElementException("Highlight with id $highlightId not found"))
             }
+        } catch (cancellationException: CancellationException) {
+            throw cancellationException
         } catch (exception: Exception) {
             Timber.e(exception)
             Result.failure(exception)
@@ -50,6 +55,8 @@ class HighlightsRepositoryImpl @Inject constructor(
         try {
             localHighlightsDataSource.deleteHighlightById(highlightId)
             Result.success(Unit)
+        } catch (cancellationException: CancellationException) {
+            throw cancellationException
         } catch (exception: Exception) {
             Timber.e(exception)
             Result.failure(exception)

--- a/core-data/src/main/java/com/sriniketh/core_data/usecases/ExportHighlightsUseCase.kt
+++ b/core-data/src/main/java/com/sriniketh/core_data/usecases/ExportHighlightsUseCase.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 
 @OptIn(ExperimentalSerializationApi::class)
 private val exportJson = Json {
@@ -58,6 +59,8 @@ class ExportHighlightsUseCase @Inject constructor(
         val fileName = "${book.info.title.lowercase().replace(" ", "_")}_export.json"
         val uri = fileSource.writeToFile(fileName, json)
         Result.success(uri)
+    } catch (cancellationException: CancellationException) {
+        throw cancellationException
     } catch (exception: Exception) {
         Result.failure(exception)
     }

--- a/core-data/src/test/java/com/sriniketh/core_data/BooksRepositoryImplTest.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/BooksRepositoryImplTest.kt
@@ -6,6 +6,10 @@ import com.sriniketh.core_data.fakes.FakeBooksRemoteDataSource
 import com.sriniketh.core_db.entity.BookEntity
 import com.sriniketh.core_models.book.Book
 import com.sriniketh.core_models.book.BookInfo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -14,6 +18,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class BooksRepositoryImplTest {
 
 	private lateinit var booksRemoteDataSource: FakeBooksRemoteDataSource
@@ -65,6 +70,26 @@ class BooksRepositoryImplTest {
 			val exception = result.exceptionOrNull()
 			assertTrue(exception is RuntimeException)
 			assertEquals("some error fetching volumes", exception?.message)
+		}
+
+	@Test
+	fun `searchForBooks propagates CancellationException instead of converting it to a failure Result when the calling coroutine is cancelled`() =
+		runTest {
+			booksRemoteDataSource.shouldGetVolumesSuspendForever = true
+			var thrown: Throwable? = null
+
+			val job = launch {
+				try {
+					booksRepositoryImpl.searchForBooks("some query")
+				} catch (throwable: Throwable) {
+					thrown = throwable
+				}
+			}
+			runCurrent()
+			job.cancel()
+			job.join()
+
+			assertTrue(thrown is CancellationException)
 		}
 
 	@Test

--- a/core-data/src/test/java/com/sriniketh/core_data/HighlightsRepositoryImplTest.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/HighlightsRepositoryImplTest.kt
@@ -4,12 +4,17 @@ import app.cash.turbine.test
 import com.sriniketh.core_data.fakes.FakeHighlightDao
 import com.sriniketh.core_db.entity.HighlightEntity
 import com.sriniketh.core_models.book.Highlight
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class HighlightsRepositoryImplTest {
 
     private lateinit var highlightDao: FakeHighlightDao
@@ -51,6 +56,29 @@ class HighlightsRepositoryImplTest {
             val exception = result.exceptionOrNull()
             assertTrue(exception is RuntimeException)
             assertEquals("some error inserting highlight", exception?.message)
+        }
+
+    @Test
+    fun `insertHighlightIntoDb propagates CancellationException instead of converting it to a failure result when the calling coroutine is cancelled`() =
+        runTest {
+            val highlight = Highlight(
+                id = "possim", bookId = "eius", text = "ignota", savedOnTimestamp = "diam"
+            )
+            highlightDao.shouldInsertHighlightSuspendForever = true
+            var thrown: Throwable? = null
+
+            val job = launch {
+                try {
+                    highlightsRepositoryImpl.insertHighlightIntoDb(highlight)
+                } catch (throwable: Throwable) {
+                    thrown = throwable
+                }
+            }
+            runCurrent()
+            job.cancel()
+            job.join()
+
+            assertTrue(thrown is CancellationException)
         }
 
     @Test

--- a/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeBooksRemoteDataSource.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeBooksRemoteDataSource.kt
@@ -5,13 +5,16 @@ import com.sriniketh.prose.core_network.model.ImageLinks
 import com.sriniketh.prose.core_network.model.Volume
 import com.sriniketh.prose.core_network.model.VolumeInfo
 import com.sriniketh.prose.core_network.model.Volumes
+import kotlinx.coroutines.awaitCancellation
 
 class FakeBooksRemoteDataSource : BooksRemoteDataSource {
 
     var shouldGetVolumesThrowException = false
+    var shouldGetVolumesSuspendForever = false
     var searchQueryPassed: String? = null
     override suspend fun getVolumes(searchQuery: String): Volumes {
         searchQueryPassed = searchQuery
+        if (shouldGetVolumesSuspendForever) awaitCancellation()
         return if (shouldGetVolumesThrowException) throw RuntimeException("some error fetching volumes")
         else Volumes(items = listOf(volume1()))
     }

--- a/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeBooksRepository.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeBooksRepository.kt
@@ -4,6 +4,7 @@ import com.sriniketh.core_data.BooksRepository
 import com.sriniketh.core_models.book.Book
 import com.sriniketh.core_models.book.BookInfo
 import com.sriniketh.core_models.search.BookSearch
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -16,6 +17,7 @@ class FakeBooksRepository : BooksRepository {
 	var shouldDoesBookExistInDbThrowException = false
 	var shouldDeleteBookFromDbThrowException = false
 	var shouldGetBookByIdFromDbThrowException = false
+	var shouldGetBookByIdFromDbSuspendForever = false
 
 	var searchQueryPassed: String? = null
 	var volumeIdPassed: String? = null
@@ -85,6 +87,7 @@ class FakeBooksRepository : BooksRepository {
 	}
 
 	override suspend fun getBookByIdFromDb(bookId: String): Result<Book> {
+		if (shouldGetBookByIdFromDbSuspendForever) awaitCancellation()
 		return if (shouldGetBookByIdFromDbThrowException) {
 			Result.failure(NoSuchElementException("Book not found"))
 		} else {

--- a/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeHighlightDao.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeHighlightDao.kt
@@ -2,6 +2,7 @@ package com.sriniketh.core_data.fakes
 
 import com.sriniketh.core_db.dao.HighlightDao
 import com.sriniketh.core_db.entity.HighlightEntity
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -10,7 +11,9 @@ class FakeHighlightDao : HighlightDao {
 
     var insertedHighlightEntity: HighlightEntity? = null
     var shouldInsertHighlightThrowException = false
+    var shouldInsertHighlightSuspendForever = false
     override suspend fun insertHighlight(highlightEntity: HighlightEntity) {
+        if (shouldInsertHighlightSuspendForever) awaitCancellation()
         if (shouldInsertHighlightThrowException) {
             throw RuntimeException("some error inserting highlight")
         }

--- a/core-data/src/test/java/com/sriniketh/core_data/usecases/ExportHighlightsUseCaseTest.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/usecases/ExportHighlightsUseCaseTest.kt
@@ -6,6 +6,10 @@ import com.sriniketh.core_data.fakes.FakeHighlightsRepository
 import com.sriniketh.core_data.models.HighlightsExport
 import com.sriniketh.core_models.book.Book
 import com.sriniketh.core_models.book.BookInfo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -16,6 +20,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ExportHighlightsUseCaseTest {
 
     private lateinit var fakeBooksRepository: FakeBooksRepository
@@ -51,6 +56,26 @@ class ExportHighlightsUseCaseTest {
         assertTrue(writtenContent.contains("Test highlight text"))
         assertEquals("test_title_export.json", fakeFileSource.lastWrittenFileName)
     }
+
+    @Test
+    fun `propagates CancellationException instead of converting it to a failure result when the calling coroutine is cancelled`() =
+        runTest {
+            fakeBooksRepository.shouldGetBookByIdFromDbSuspendForever = true
+            var thrown: Throwable? = null
+
+            val job = launch {
+                try {
+                    useCase("test-book-id")
+                } catch (throwable: Throwable) {
+                    thrown = throwable
+                }
+            }
+            runCurrent()
+            job.cancel()
+            job.join()
+
+            assertTrue(thrown is CancellationException)
+        }
 
     @Test
     fun `when book not found then returns failure`() = runTest {

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/ImageRotater.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/ImageRotater.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 import androidx.exifinterface.media.ExifInterface
 import com.sriniketh.core_platform.logTag
 import timber.log.Timber
+import kotlin.coroutines.cancellation.CancellationException
 
 internal object ImageRotater {
 
@@ -41,6 +42,8 @@ internal object ImageRotater {
                 Timber.d("${this.logTag()}: Bitmap rotated successfully")
                 return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
             }
+        } catch (cancellationException: CancellationException) {
+            throw cancellationException
         } catch (exception: Exception) {
             Timber.e(exception, this.logTag())
             return null


### PR DESCRIPTION
## Summary
`CancellationException` was swallowed by `catch (e: Exception)` in every repository/use-case implementation (`BooksRepositoryImpl`, `HighlightsRepositoryImpl`, `ExportHighlightsUseCase`, `ImageRotater`), breaking structured concurrency — e.g. a cancelled stale search (via `flatMapLatest`) got treated as a real error and could fire a spurious snackbar for a query the user already superseded. `EditAndSaveHighlightViewModel.kt` already had the correct pattern.

## Fix
Added `catch (ce: CancellationException) { throw ce }` before the general `catch (e: Exception)` at all 11 sites across the 4 files. The two `Flow.catch {}` operators (`getAllSavedBooksFromDb`, `getAllHighlightsForBookFromDb`) were left untouched — kotlinx.coroutines' `catchImpl` already rethrows `CancellationException` internally before invoking the handler, so they were already correct.

Exhaustive repo-wide grep for `catch (` / `runCatching` confirmed exactly 13 total catch blocks exist — the 11 fixed here, the 2 already-safe `Flow.catch` sites, and the 1 pre-existing correct site — nothing else needed fixing.

## Test plan
- 3 new tests (one per repository/use-case type) launch a coroutine, cancel it mid-suspend via a fake's `awaitCancellation()`, and assert `CancellationException` propagates instead of converting to `Result.failure`.
- TDD verified for real: reverting the production fix reproduces exactly 3 failures (the new tests) with the rest of the suite green.
- `./gradlew :core-data:test :feature-addhighlight:testDebugUnitTest` and full `./gradlew test` — all green.

No dedicated test was added for `ImageRotater` (needs Android framework classes; the module has no Robolectric setup) — the fix was still applied there per the review's explicit instruction, matching a pre-existing coverage gap rather than introducing a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)