### PR TITLE
fix: enable R8 minification for release, add missing keep rules

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,8 @@ android {
 
 	buildTypes {
 		release {
-			isMinifyEnabled = false
+			isMinifyEnabled = true
+			isShrinkResources = true
 			proguardFiles(
 				getDefaultProguardFile("proguard-android-optimize.txt"),
 				"proguard-rules.pro"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,12 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-assumenosideeffects class timber.log.Timber* {
+    public static *** v(...);
+    public static *** d(...);
+    public static *** i(...);
+    public static *** w(...);
+    public static *** e(...);
+    public static *** wtf(...);
+}

--- a/core-data/consumer-rules.pro
+++ b/core-data/consumer-rules.pro
@@ -1,0 +1,27 @@
+# kotlinx-serialization rules
+# Keep `Companion` object fields of serializable classes.
+# This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+
+# Keep `serializer()` on companion objects (both default and named) of serializable classes.
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Keep `INSTANCE.serializer()` of serializable objects.
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault

--- a/core-network/consumer-rules.pro
+++ b/core-network/consumer-rules.pro
@@ -1,0 +1,27 @@
+# kotlinx-serialization rules
+# Keep `Companion` object fields of serializable classes.
+# This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+
+# Keep `serializer()` on companion objects (both default and named) of serializable classes.
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Keep `INSTANCE.serializer()` of serializable objects.
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault


### PR DESCRIPTION
## Summary
`isMinifyEnabled = false` in every module's release block left the API key and all app code trivially readable in the release APK (`strings classes.dex`).

## Fix — deviates from a literal "enable on every module" reading; see rationale below
- `isMinifyEnabled = true` + `isShrinkResources = true` on **`:app` only**, not on the 9 library modules. In this repo's multi-module setup, libraries are consumed via `project(...)` dependencies, not published AARs — enabling `isMinifyEnabled` per-library gives that module its own isolated R8 pass with no visibility into cross-module usage, which broke the build (Hilt codegen failures from R8 stripping classes like `FetchBookInfoUseCase`/`BooksRemoteDataSource` that looked "unused" from inside their own module). The single R8 pass that matters — the one on `:app` — processes the full merged program and correctly shrinks/obfuscates library code too; verified via the release `mapping.txt` showing library classes renamed.
- kotlinx.serialization consumer-rules added to `core-network/consumer-rules.pro` (as originally identified) and **`core-data/consumer-rules.pro`** rather than `core-db` — `core-db` has zero `@Serializable` usage (plain delimiter-joined strings), while `core-data` defines the `@Serializable` export models and had an empty consumer-rules file despite already having the correct rules sitting unused in its own `proguard-rules.pro`.
- Timber `-assumenosideeffects` strip rule added to `app/proguard-rules.pro`, covering all Timber log levels actually used in this codebase.

## Known limitation
R8 minification doesn't obfuscate string constants — `BOOKS_API_KEY` is still present verbatim in the release dex. This PR only removes the "readable code structure" half of the finding; actually protecting the key value requires restricting it in Google Cloud Console (a separate, non-code action).

## Test plan
- `./gradlew assembleRelease` — succeeds; verified via `mapping.txt` (~380k renamed members) and `strings classes.dex` that obfuscation is real and Timber log-message strings are gone from the dex.
- `./gradlew test` — all modules green.

Both deviations from the literal task instructions were independently re-verified during review (build re-run, `core-db`/`core-data` serialization usage re-checked from source) and confirmed correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)