### PR TITLE
fix: close ML Kit recognizer on all completion paths

### DIFF
--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/TextAnalyzer.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/TextAnalyzer.kt
@@ -23,10 +23,12 @@ class TextAnalyzerImpl @Inject constructor(@ApplicationContext private val appCo
                 .addOnSuccessListener {
                     Timber.d("${this.logTag()}: Recognized text: ${it.text}")
                     continuation.resumeWith(Result.success(it))
+                    recognizer.close()
                 }
                 .addOnFailureListener {
                     Timber.e(it, this.logTag())
                     continuation.resumeWith(Result.failure(it))
+                    recognizer.close()
                 }
             continuation.invokeOnCancellation { recognizer.close() }
         }

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/TextAnalyzer.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/TextAnalyzer.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.Text
 import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.TextRecognizer
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.sriniketh.core_platform.logTag
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -15,9 +16,19 @@ import javax.inject.Inject
 class TextAnalyzerImpl @Inject constructor(@ApplicationContext private val appContext: Context) :
     TextAnalyzer {
 
+    private var recognizerFactory: () -> TextRecognizer =
+        { TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS) }
+
+    internal constructor(
+        appContext: Context,
+        recognizerFactory: () -> TextRecognizer
+    ) : this(appContext) {
+        this.recognizerFactory = recognizerFactory
+    }
+
     override suspend fun analyzeImage(uri: Uri): Text =
         suspendCancellableCoroutine { continuation ->
-            val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+            val recognizer = recognizerFactory()
             val image = InputImage.fromFilePath(appContext, uri)
             recognizer.process(image)
                 .addOnSuccessListener {

--- a/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/TextAnalyzerImplTest.kt
+++ b/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/TextAnalyzerImplTest.kt
@@ -1,0 +1,95 @@
+package com.sriniketh.feature_addhighlight
+
+import android.content.Context
+import android.net.Uri
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.Text
+import com.google.mlkit.vision.text.TextRecognizer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TextAnalyzerImplTest {
+
+    private lateinit var appContext: Context
+    private lateinit var recognizer: TextRecognizer
+    private lateinit var task: Task<Text>
+    private lateinit var textAnalyzer: TextAnalyzerImpl
+
+    @Before
+    fun setup() {
+        appContext = mockk()
+        recognizer = mockk(relaxUnitFun = true)
+        task = mockk()
+
+        mockkStatic(InputImage::class)
+        every { InputImage.fromFilePath(any(), any()) } returns mockk()
+        every { recognizer.process(any<InputImage>()) } returns task
+
+        textAnalyzer = TextAnalyzerImpl(appContext) { recognizer }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(InputImage::class)
+    }
+
+    @Test
+    fun `when recognition succeeds then recognizer is closed`() = runTest {
+        val recognizedText = mockk<Text> {
+            every { text } returns "Recognized text"
+        }
+        every { task.addOnSuccessListener(any()) } answers {
+            firstArg<OnSuccessListener<Text>>().onSuccess(recognizedText)
+            task
+        }
+        every { task.addOnFailureListener(any()) } returns task
+
+        val result = textAnalyzer.analyzeImage(mockk())
+
+        assertEquals(recognizedText, result)
+        verify(exactly = 1) { recognizer.close() }
+    }
+
+    @Test
+    fun `when recognition fails then recognizer is closed`() = runTest {
+        val failure = RuntimeException("recognition failed")
+        every { task.addOnSuccessListener(any()) } returns task
+        every { task.addOnFailureListener(any()) } answers {
+            firstArg<OnFailureListener>().onFailure(failure)
+            task
+        }
+
+        val thrown = runCatching { textAnalyzer.analyzeImage(mockk()) }.exceptionOrNull()
+
+        assertEquals(failure.message, thrown?.message)
+        verify(exactly = 1) { recognizer.close() }
+    }
+
+    @Test
+    fun `when recognition is cancelled then recognizer is closed`() = runTest {
+        every { task.addOnSuccessListener(any()) } returns task
+        every { task.addOnFailureListener(any()) } returns task
+
+        val job = launch { textAnalyzer.analyzeImage(mockk()) }
+        advanceUntilIdle()
+        job.cancelAndJoin()
+
+        verify(exactly = 1) { recognizer.close() }
+    }
+}


### PR DESCRIPTION
## Summary
`TextAnalyzer.kt` created a new `TextRecognition.getClient(...)` per OCR call and closed it only in `invokeOnCancellation` — never on the normal success/failure completion paths, leaking the recognizer client on every OCR call that completed normally (the vast majority).

## Fix
`recognizer.close()` is now called on all three completion paths: success, failure, and cancellation.

## Test plan
Introduced a minimal test seam (`recognizerFactory: () -> TextRecognizer` + an `internal` secondary constructor) since `TextAnalyzerImpl` previously called the ML Kit static factory directly with no way to substitute a fake — doesn't affect Hilt DI (only the `@Inject`-annotated primary constructor is visible to it).

New `TextAnalyzerImplTest.kt` (MockK, per project convention), 3 cases: success → close() called, failure → close() called, cancellation → close() called. TDD verified for real: removing the success/failure close() calls (keeping cancellation) reproduces exactly 2 failures, matching the tests added.

`./gradlew :feature-addhighlight:testDebugUnitTest` — all green (3 new + 15 existing, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)