### PR TITLE
refactor: migrate navigation to type-safe @Serializable routes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 	alias(libs.plugins.kotlin.compose)
 	alias(libs.plugins.ksp)
 	alias(libs.plugins.hilt)
+	alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin {
@@ -60,11 +61,16 @@ dependencies {
 	implementation(libs.bundles.compose)
 	debugImplementation(libs.compose.ui.tooling)
 	implementation(libs.navigation.compose)
+	implementation(libs.kotlinx.serialization.json)
 
 	implementation(libs.hilt.android)
 	ksp(libs.hilt.compiler)
 
 	testImplementation(libs.junit)
+	androidTestImplementation(composeBom)
 	androidTestImplementation(libs.android.junit)
 	androidTestImplementation(libs.espresso.core)
+	androidTestImplementation(libs.compose.junit)
+	androidTestImplementation(libs.navigation.testing)
+	debugImplementation(libs.compose.test.manifest)
 }

--- a/app/src/androidTest/java/com/sriniketh/prose/NavigationRouteTest.kt
+++ b/app/src/androidTest/java/com/sriniketh/prose/NavigationRouteTest.kt
@@ -1,0 +1,140 @@
+package com.sriniketh.prose
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.testing.TestNavHostController
+import androidx.navigation.toRoute
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NavigationRouteTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var navController: NavHostController
+
+    private fun setUpNavGraph() {
+        composeTestRule.setContent {
+            navController = TestNavHostController(LocalContext.current).apply {
+                navigatorProvider.addNavigator(ComposeNavigator())
+            }
+            NavHost(navController = navController, startDestination = Bookshelf) {
+                composable<Bookshelf> { DestinationMarker("bookshelf") }
+                composable<Search> { DestinationMarker("search") }
+                composable<BookInfo> { DestinationMarker("book_info") }
+                composable<ViewHighlights> { DestinationMarker("view_highlights") }
+                composable<CaptureAndCropImage> { DestinationMarker("capture_and_crop_image") }
+                composable<SaveHighlightFromUri> { DestinationMarker("save_highlight_from_uri") }
+                composable<SaveHighlightFromHighlightId> { DestinationMarker("save_highlight_from_highlight_id") }
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun navigateTo(route: Any) {
+        composeTestRule.runOnUiThread { navController.navigate(route) }
+        composeTestRule.waitForIdle()
+    }
+
+    @Test
+    fun startDestinationIsBookshelf() {
+        setUpNavGraph()
+
+        composeTestRule.onNodeWithTag("bookshelf").assertIsDisplayed()
+        assertEquals(
+            true,
+            navController.currentBackStackEntry!!.destination.hasRoute(Bookshelf::class)
+        )
+    }
+
+    @Test
+    fun navigateToSearchReachesSearchDestination() {
+        setUpNavGraph()
+
+        navigateTo(Search)
+
+        assertEquals(
+            true,
+            navController.currentBackStackEntry!!.destination.hasRoute(Search::class)
+        )
+    }
+
+    @Test
+    fun navigateToBookInfoDeliversBookId() {
+        setUpNavGraph()
+
+        navigateTo(BookInfo("book-info-42"))
+
+        assertEquals(
+            "book-info-42",
+            navController.currentBackStackEntry!!.toRoute<BookInfo>().bookId
+        )
+    }
+
+    @Test
+    fun navigateToViewHighlightsDeliversBookId() {
+        setUpNavGraph()
+
+        navigateTo(ViewHighlights("book-99"))
+
+        assertEquals(
+            "book-99",
+            navController.currentBackStackEntry!!.toRoute<ViewHighlights>().bookId
+        )
+    }
+
+    @Test
+    fun navigateToCaptureAndCropImageDeliversBookId() {
+        setUpNavGraph()
+
+        navigateTo(CaptureAndCropImage("book-7"))
+
+        assertEquals(
+            "book-7",
+            navController.currentBackStackEntry!!.toRoute<CaptureAndCropImage>().bookId
+        )
+    }
+
+    @Test
+    fun navigateToSaveHighlightFromHighlightIdDeliversBothArgs() {
+        setUpNavGraph()
+
+        navigateTo(SaveHighlightFromHighlightId("book-1", "highlight-2"))
+
+        val route = navController.currentBackStackEntry!!.toRoute<SaveHighlightFromHighlightId>()
+        assertEquals("book-1", route.bookId)
+        assertEquals("highlight-2", route.highlightId)
+    }
+
+    @Test
+    fun navigateToSaveHighlightFromUriPreservesUriWithReservedCharacters() {
+        setUpNavGraph()
+
+        val uri = "content://com.sriniketh.prose.provider/cache/temp image 1.jpg?x=1&y=2"
+        navigateTo(SaveHighlightFromUri("book-3", uri))
+
+        val route = navController.currentBackStackEntry!!.toRoute<SaveHighlightFromUri>()
+        assertEquals("book-3", route.bookId)
+        assertEquals(uri, route.uri)
+    }
+}
+
+@androidx.compose.runtime.Composable
+private fun DestinationMarker(tag: String) {
+    Text(text = tag, modifier = Modifier.testTag(tag))
+}

--- a/app/src/main/java/com/sriniketh/prose/Navigation.kt
+++ b/app/src/main/java/com/sriniketh/prose/Navigation.kt
@@ -1,40 +1,24 @@
 package com.sriniketh.prose
 
-internal sealed interface Screen {
-    val route: String
+import kotlinx.serialization.Serializable
 
-    data object BOOKSHELF : Screen {
-        override val route: String = "bookshelf"
-    }
+@Serializable
+internal data object Bookshelf
 
-    data object VIEWHIGHLIGHTS : Screen {
-        override val route: String = "view_highlights"
-        const val argBookId: String = "bookId"
-    }
+@Serializable
+internal data object Search
 
-    data object CAPTUREANDCROPIMAGE : Screen {
-        override val route: String = "capture_and_crop_image"
-        const val argBookId: String = "bookId"
-    }
+@Serializable
+internal data class BookInfo(val bookId: String)
 
-    data object SAVEHIGHLIGHT_FROMURI : Screen {
-        override val route: String = "save_highlight_from_uri"
-        const val argUri: String = "uri"
-        const val argBookId: String = "bookId"
-    }
+@Serializable
+internal data class ViewHighlights(val bookId: String)
 
-    data object SAVEHIGHLIGHT_FROMHIGHLIGHTID : Screen {
-        override val route: String = "save_highlight_from_highlight_id"
-        const val argHighlightId: String = "highlightId"
-        const val argBookId: String = "bookId"
-    }
+@Serializable
+internal data class CaptureAndCropImage(val bookId: String)
 
-    data object SEARCH : Screen {
-        override val route: String = "search"
-    }
+@Serializable
+internal data class SaveHighlightFromUri(val bookId: String, val uri: String)
 
-    data object BOOKINFO : Screen {
-        override val route: String = "book_info"
-        const val argBookId: String = "bookId"
-    }
-}
+@Serializable
+internal data class SaveHighlightFromHighlightId(val bookId: String, val highlightId: String)

--- a/app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt
+++ b/app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt
@@ -4,15 +4,14 @@ import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.navigation.NavType
+import androidx.core.net.toUri
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.sriniketh.core_design.ui.LocalAnimatedVisibilityScope
 import com.sriniketh.core_design.ui.LocalSharedTransitionScope
-import com.sriniketh.core_platform.decodeUri
-import com.sriniketh.core_platform.encodeUri
 import com.sriniketh.feature_addhighlight.CaptureAndCropImageScreen
 import com.sriniketh.feature_addhighlight.EditAndSaveHighlightScreen
 import com.sriniketh.feature_bookshelf.BOOKSHELF_SHOW_ADDED_MESSAGE
@@ -23,151 +22,97 @@ import com.sriniketh.feature_viewhighlights.ViewHighlightsScreen
 
 @Composable
 internal fun ProseAppScreen(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    navController: NavHostController = rememberNavController()
 ) {
-    val navController = rememberNavController()
     SharedTransitionLayout {
         CompositionLocalProvider(LocalSharedTransitionScope provides this) {
             NavHost(
                 navController = navController,
-                startDestination = Screen.BOOKSHELF.route
+                startDestination = Bookshelf
             ) {
-                composable(Screen.BOOKSHELF.route) {
+                composable<Bookshelf> {
                     CompositionLocalProvider(LocalAnimatedVisibilityScope provides this) {
                         BookshelfScreen(
                             modifier = modifier,
-                            goToSearch = { navController.navigate(Screen.SEARCH.route) },
+                            goToSearch = { navController.navigate(Search) },
                             goToHighlight = { bookId ->
-                                navController.navigate("${Screen.VIEWHIGHLIGHTS.route}/$bookId")
+                                navController.navigate(ViewHighlights(bookId))
                             }
                         )
                     }
                 }
-                composable(Screen.SEARCH.route) {
+                composable<Search> {
                     CompositionLocalProvider(LocalAnimatedVisibilityScope provides this) {
                         SearchBookScreen(
                             modifier = modifier,
                             goToBookInfo = { bookId ->
-                                navController.navigate("${Screen.BOOKINFO.route}/$bookId")
+                                navController.navigate(BookInfo(bookId))
                             }
                         )
                     }
                 }
-                composable(
-                    route = "${Screen.VIEWHIGHLIGHTS.route}/{${Screen.VIEWHIGHLIGHTS.argBookId}}",
-                    arguments = listOf(navArgument(Screen.VIEWHIGHLIGHTS.argBookId) {
-                        type = NavType.StringType
-                    })
-                ) { backStackEntry ->
-                    val bookId =
-                        backStackEntry.arguments?.getString(Screen.VIEWHIGHLIGHTS.argBookId)
-                            .orEmpty()
+                composable<ViewHighlights> { backStackEntry ->
+                    val bookId = backStackEntry.toRoute<ViewHighlights>().bookId
                     ViewHighlightsScreen(
                         modifier = modifier,
                         bookId = bookId,
                         goBack = { navController.navigateUp() },
                         goToAddHighlightScreen = {
-                            navController.navigate("${Screen.CAPTUREANDCROPIMAGE.route}/$bookId")
+                            navController.navigate(CaptureAndCropImage(bookId))
                         },
                         goToEditHighlightScreen = { highlightId ->
-                            navController.navigate("${Screen.SAVEHIGHLIGHT_FROMHIGHLIGHTID.route}/$bookId/$highlightId")
+                            navController.navigate(SaveHighlightFromHighlightId(bookId, highlightId))
                         }
                     )
                 }
-                composable(
-                    route = "${Screen.CAPTUREANDCROPIMAGE.route}/{${Screen.CAPTUREANDCROPIMAGE.argBookId}}",
-                    arguments = listOf(navArgument(Screen.CAPTUREANDCROPIMAGE.argBookId) {
-                        type = NavType.StringType
-                    })
-                ) { backStackEntry ->
-                    val bookId =
-                        backStackEntry.arguments?.getString(Screen.CAPTUREANDCROPIMAGE.argBookId)
-                            .orEmpty()
+                composable<CaptureAndCropImage> { backStackEntry ->
+                    val bookId = backStackEntry.toRoute<CaptureAndCropImage>().bookId
                     CaptureAndCropImageScreen(
                         modifier = modifier,
                         onImageCaptured = { imageUri ->
-                            val encodedUri = imageUri.encodeUri()
-                            navController.navigate("${Screen.SAVEHIGHLIGHT_FROMURI.route}/$bookId/$encodedUri")
+                            navController.navigate(SaveHighlightFromUri(bookId, imageUri.toString()))
                         },
                         goBack = {
-                            navController.popBackStack(
-                                "${Screen.CAPTUREANDCROPIMAGE.route}/$bookId",
-                                inclusive = true
-                            )
+                            navController.popBackStack(CaptureAndCropImage(bookId), inclusive = true)
                         }
                     )
                 }
-                composable(
-                    route = "${Screen.SAVEHIGHLIGHT_FROMURI.route}/{${Screen.SAVEHIGHLIGHT_FROMURI.argBookId}}/{${Screen.SAVEHIGHLIGHT_FROMURI.argUri}}",
-                    arguments = listOf(
-                        navArgument(Screen.SAVEHIGHLIGHT_FROMURI.argBookId) {
-                            type = NavType.StringType
-                        },
-                        navArgument(Screen.SAVEHIGHLIGHT_FROMURI.argUri) {
-                            type = NavType.StringType
-                        }
-                    )
-                ) { backStackEntry ->
-                    val bookId =
-                        backStackEntry.arguments?.getString(Screen.SAVEHIGHLIGHT_FROMURI.argBookId)
-                            .orEmpty()
-                    val uri =
-                        backStackEntry.arguments?.getString(Screen.SAVEHIGHLIGHT_FROMURI.argUri)
-                            .orEmpty()
+                composable<SaveHighlightFromUri> { backStackEntry ->
+                    val route = backStackEntry.toRoute<SaveHighlightFromUri>()
                     EditAndSaveHighlightScreen(
-                        uri = uri.decodeUri(),
-                        bookId = bookId,
+                        uri = route.uri.toUri(),
+                        bookId = route.bookId,
                         goBack = {
                             navController.popBackStack(
-                                "${Screen.VIEWHIGHLIGHTS.route}/$bookId",
+                                ViewHighlights(route.bookId),
                                 inclusive = false
                             )
                         }
                     )
                 }
-                composable(
-                    route = "${Screen.SAVEHIGHLIGHT_FROMHIGHLIGHTID.route}/{${Screen.SAVEHIGHLIGHT_FROMHIGHLIGHTID.argBookId}}/{${Screen.SAVEHIGHLIGHT_FROMHIGHLIGHTID.argHighlightId}}",
-                    arguments = listOf(
-                        navArgument(Screen.SAVEHIGHLIGHT_FROMHIGHLIGHTID.argBookId) {
-                            type = NavType.StringType
-                        },
-                        navArgument(Screen.SAVEHIGHLIGHT_FROMHIGHLIGHTID.argHighlightId) {
-                            type = NavType.StringType
-                        }
-                    )
-                ) { backStackEntry ->
-                    val bookId =
-                        backStackEntry.arguments?.getString(Screen.SAVEHIGHLIGHT_FROMHIGHLIGHTID.argBookId)
-                            .orEmpty()
-                    val highlightId =
-                        backStackEntry.arguments?.getString(Screen.SAVEHIGHLIGHT_FROMHIGHLIGHTID.argHighlightId)
-                            .orEmpty()
+                composable<SaveHighlightFromHighlightId> { backStackEntry ->
+                    val route = backStackEntry.toRoute<SaveHighlightFromHighlightId>()
                     EditAndSaveHighlightScreen(
-                        highlightId = highlightId,
-                        bookId = bookId,
+                        highlightId = route.highlightId,
+                        bookId = route.bookId,
                         goBack = {
                             navController.popBackStack(
-                                "${Screen.VIEWHIGHLIGHTS.route}/$bookId",
+                                ViewHighlights(route.bookId),
                                 inclusive = false
                             )
                         }
                     )
                 }
-                composable(
-                    route = "${Screen.BOOKINFO.route}/{${Screen.BOOKINFO.argBookId}}",
-                    arguments = listOf(navArgument(Screen.BOOKINFO.argBookId) {
-                        type = NavType.StringType
-                    })
-                ) { backStackEntry ->
+                composable<BookInfo> { backStackEntry ->
                     BookInfoScreen(
                         modifier = modifier,
-                        bookId = backStackEntry.arguments?.getString(Screen.BOOKINFO.argBookId)
-                            .orEmpty(),
+                        bookId = backStackEntry.toRoute<BookInfo>().bookId,
                         goBack = { navController.navigateUp() },
                         onBookAddedToShelf = {
-                            navController.getBackStackEntry(Screen.BOOKSHELF.route)
+                            navController.getBackStackEntry(Bookshelf)
                                 .savedStateHandle[BOOKSHELF_SHOW_ADDED_MESSAGE] = true
-                            navController.popBackStack(Screen.BOOKSHELF.route, inclusive = false)
+                            navController.popBackStack(Bookshelf, inclusive = false)
                         }
                     )
                 }

--- a/core-platform/src/main/java/com/sriniketh/core_platform/UriExtensions.kt
+++ b/core-platform/src/main/java/com/sriniketh/core_platform/UriExtensions.kt
@@ -1,11 +1,6 @@
 package com.sriniketh.core_platform
 
 import android.net.Uri
-import androidx.core.net.toUri
 
 fun String?.buildHttpsUri(): Uri? =
     if (this == null) null else Uri.parse(this).buildUpon().apply { scheme("https") }.build()
-
-fun Uri.encodeUri(): String = Uri.encode(this.toString())
-
-fun String.decodeUri(): Uri = Uri.decode(this).toUri()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,25 +159,32 @@ is `@HiltAndroidApp` and plants a Timber `DebugTree` in debug builds.
 
 ## Navigation
 
-Navigation Compose with **string routes**, defined as a sealed interface in
+Navigation Compose with **type-safe `@Serializable` routes** (Navigation 2.8+ pattern), defined as
+`@Serializable` `data object`/`data class` route types in
 [`Navigation.kt`](../app/src/main/java/com/sriniketh/prose/Navigation.kt) and wired in
-[`ProseAppScreen.kt`](../app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt). The start
-destination is `bookshelf`. Arguments are passed as path segments (`view_highlights/{bookId}`).
+[`ProseAppScreen.kt`](../app/src/main/java/com/sriniketh/prose/ProseAppScreen.kt) via
+`composable<RouteType> { ... }`. The start destination is the `Bookshelf` route object. Navigation
+is done with route instances (`navController.navigate(ViewHighlights(bookId))`); arguments are read
+with `backStackEntry.toRoute<RouteType>()` — a missing/mismatched arg fails loudly instead of
+silently becoming `""`.
 
-| Route | Screen | Args |
+| Route type | Screen | Args |
 |-------|--------|------|
-| `bookshelf` | Bookshelf (start) | — |
-| `search` | Book search | — |
-| `book_info/{bookId}` | Book detail / add-to-shelf | `bookId` |
-| `view_highlights/{bookId}` | Highlights list | `bookId` |
-| `capture_and_crop_image/{bookId}` | Camera + crop | `bookId` |
-| `save_highlight_from_uri/{bookId}/{uri}` | OCR + save new highlight | `bookId`, encoded `uri` |
-| `save_highlight_from_highlight_id/{bookId}/{highlightId}` | Edit existing highlight | `bookId`, `highlightId` |
+| `Bookshelf` | Bookshelf (start) | — |
+| `Search` | Book search | — |
+| `BookInfo` | Book detail / add-to-shelf | `bookId: String` |
+| `ViewHighlights` | Highlights list | `bookId: String` |
+| `CaptureAndCropImage` | Camera + crop | `bookId: String` |
+| `SaveHighlightFromUri` | OCR + save new highlight | `bookId: String`, `uri: String` |
+| `SaveHighlightFromHighlightId` | Edit existing highlight | `bookId: String`, `highlightId: String` |
 
 Notes:
-- The image `uri` is URL-encoded/decoded across the route boundary via
-  [`UriExtensions`](../core-platform/src/main/java/com/sriniketh/core_platform/UriExtensions.kt)
-  (`encodeUri()` / `decodeUri()`).
+- The image `uri` is carried as a plain `String` route arg; Navigation Compose handles the
+  URL-encoding/decoding for type-safe routes, so no manual `encodeUri`/`decodeUri` round-trip is
+  needed. `ProseAppScreen` converts it back to a `Uri` with `String.toUri()` at the destination.
+- `popBackStack`/`getBackStackEntry` also take route instances
+  (`popBackStack(ViewHighlights(bookId), inclusive = false)`), so route renames are compile-time
+  checked rather than silent runtime string mismatches.
 - Cross-screen results use `savedStateHandle` on a back-stack entry. Adding a book sets
   `BOOKSHELF_SHOW_ADDED_MESSAGE` on the bookshelf entry, then pops back to it; the bookshelf
   ViewModel observes that handle and shows a confirmation snackbar.

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -46,7 +46,7 @@ Details:
   reset.
 - DB errors map to `Result.failure` (caught in the repository's `.catch`) → `getallbooks` error
   snackbar.
-- Tapping a book navigates to `view_highlights/{bookId}`; the FAB navigates to `search`.
+- Tapping a book navigates to `ViewHighlights(bookId)`; the FAB navigates to `Search`.
 
 ---
 
@@ -117,8 +117,8 @@ Actions are dispatched through `processAction(ViewHighlightsAction)`
 - **Camera permission denied** → `permission_denied` snackbar. The screen's camera-permission
   launcher requests `CAMERA`; on grant it navigates into the capture flow, on deny it dispatches the
   denied action.
-- Adding a highlight navigates to `capture_and_crop_image/{bookId}`; editing one navigates to
-  `save_highlight_from_highlight_id/{bookId}/{highlightId}`.
+- Adding a highlight navigates to `CaptureAndCropImage(bookId)`; editing one navigates to
+  `SaveHighlightFromHighlightId(bookId, highlightId)`.
 
 ---
 
@@ -129,7 +129,7 @@ This is the most involved flow and spans two ViewModels and three navigation des
 ### 5a. Capture & crop
 
 ```
-capture_and_crop_image/{bookId}
+CaptureAndCropImage(bookId)
   → CaptureAndCropImageScreen + CaptureAndCropImageViewModel
       imageUri = CreateTempImageFileUseCase()  → FileSource.createNewFile("<uuid>.jpg")
                  (cacheDir file, exposed via FileProvider; stored in SavedStateHandle)
@@ -141,8 +141,9 @@ Steps ([`CaptureAndCropImageViewModel`](../feature-addhighlight/src/main/java/co
 1. **CaptureImage** — a `TakePicture` activity-result launcher writes the photo into the temp
    FileProvider URI. On cancel/failure the screen calls `goBack()`.
 2. **CropImage** — `CropImageScreen` (Cropify) lets the user crop; `onImageCropped()` advances state.
-3. **ImageCapturedAndCropped** — the screen calls `onImageCaptured(uri)`, which URL-encodes the URI
-   and navigates to `save_highlight_from_uri/{bookId}/{encodedUri}`.
+3. **ImageCapturedAndCropped** — the screen calls `onImageCaptured(uri)`, which navigates to
+   `SaveHighlightFromUri(bookId, uri.toString())`; Navigation Compose URL-encodes the URI string
+   for the type-safe route.
 4. **Cleanup** — `onCleared()` deletes the temp file *unless* the flow completed
    (`ImageCapturedAndCropped`), so abandoned captures don't leak files. The completed file is handed
    off to the next screen, which deletes it after OCR.
@@ -150,7 +151,7 @@ Steps ([`CaptureAndCropImageViewModel`](../feature-addhighlight/src/main/java/co
 ### 5b. OCR & save
 
 ```
-save_highlight_from_uri/{bookId}/{uri}
+SaveHighlightFromUri(bookId, uri)
   → EditAndSaveHighlightScreen(uri) + EditAndSaveHighlightViewModel
       processImageForHighlightText(uri):
         → TextAnalyzer.analyzeImage(uri)        (ML Kit on-device Latin OCR)
@@ -162,7 +163,7 @@ save_highlight_from_uri/{bookId}/{uri}
       → SaveHighlightUseCase → HighlightsRepository.insertHighlightIntoDb
           → HighlightDao.insertHighlight(highlight.asHighlightEntity())  (onConflict = REPLACE)
       timestamp = FormatCurrentDateTimeUseCase(DateTimeSource.now())
-  → Effect.HighlightSaved → goBack to view_highlights/{bookId}
+  → Effect.HighlightSaved → goBack to ViewHighlights(bookId)
 ```
 
 Details:
@@ -175,7 +176,7 @@ Details:
 ### 5c. Edit an existing highlight
 
 ```
-save_highlight_from_highlight_id/{bookId}/{highlightId}
+SaveHighlightFromHighlightId(bookId, highlightId)
   → EditAndSaveHighlightViewModel.loadHighlightText(highlightId)
       → LoadHighlightUseCase → HighlightsRepository.loadHighlightFromDb → HighlightDao.getHighlightById
   ← prefilled text + screen title switches to "edit"; original savedOnTimestamp is preserved

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -79,7 +79,7 @@ Android OS abstractions that keep upper layers testable and `Context`-free.
 - [`DateTimeSource`](../core-platform/src/main/java/com/sriniketh/core_platform/DateTimeSource.kt) —
   injectable `now()` (impl + Hilt binding here).
 - [`UriExtensions`](../core-platform/src/main/java/com/sriniketh/core_platform/UriExtensions.kt) —
-  `encodeUri()`, `decodeUri()`, `buildHttpsUri()`.
+  `buildHttpsUri()`.
 - [`LogExtensions`](../core-platform/src/main/java/com/sriniketh/core_platform/LogExtensions.kt) —
   `logTag()`.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ compose-material3 = { group = "androidx.compose.material3", name = "material3", 
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "compose-nav-version" }
+navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "compose-nav-version" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt-version" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt-version" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room-version" }


### PR DESCRIPTION
## Summary
Navigation used hand-rolled string routes with manual interpolation, hand-rolled URI encoding (`encodeUri`/`decodeUri`), and `arguments?.getString(...).orEmpty()` reads — a missing/mismatched arg silently became `""` and flowed into DAO queries instead of failing loudly. `goBack` popped a hand-built route string with no compile-time safety.

## Fix
Migrated all 7 routes to `@Serializable` types (`Bookshelf`, `Search`, `BookInfo(bookId)`, `ViewHighlights(bookId)`, `CaptureAndCropImage(bookId)`, `SaveHighlightFromUri(bookId, uri)`, `SaveHighlightFromHighlightId(bookId, highlightId)`). `ProseAppScreen.kt` uses `composable<RouteType>` and `toRoute<T>()` throughout — no leftover manual `arguments?.getString(...)` anywhere. Deleted the `encodeUri`/`decodeUri` round-trip entirely; the image URI now rides as a plain `String` route arg (Navigation Compose handles the encoding) reconstructed via `.toUri()` at the destination.

## ⚠️ Merge-order dependency on PR #142
**This branch was cut before PR #142 (SavedStateHandle nav-arg refactor) merged**, so it does not touch any ViewModel's `SavedStateHandle` access — screens still pass args as composable params exactly as before; only `ProseAppScreen`'s route-reading/building code changed. Expect a `ProseAppScreen.kt` merge conflict against #142, plus a design decision: verified that Navigation Compose 2.8+ type-safe routes populate `SavedStateHandle` under keys matching each route property's name (confirmed via how `SavedStateHandle.toRoute<T>()` itself works), so **#142's existing `savedStateHandle.get<String>("bookId")`-style reads will keep working unchanged** once this lands — no forced migration to `toRoute<T>()` in feature-module VMs, since the route classes are `internal` to `:app` and would need hoisting to a shared module if `toRoute<T>()` were wanted there instead. Recommend merging #142 first, then rebasing this branch.

## Test plan
- New instrumented `NavigationRouteTest` (`TestNavHostController`, 7 cases) navigates to every destination and asserts args via `toRoute<T>()`, including a URI with reserved characters (`content://.../temp image 1.jpg?x=1&y=2`) — the case that would catch the old silent-empty-string bug.
- **Actually run on Pixel_8 API 34: 7/7 pass** (verified after initial review, which had only compiled it).
- `./gradlew test` (all modules) + `./gradlew assembleDebug` — pass.
- `docs/architecture.md`, `docs/flows.md`, `docs/modules.md` updated per AGENTS.md's sync rule.

## Known test-coverage note
The new test validates route/arg serialization correctness using stub destinations, not `ProseAppScreen`'s actual screen-wiring — a wrong-screen mapping there wouldn't be caught by this suite. Existing screen-level tests cover that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)