### PR TITLE
fix: crop screen silent failures + off-main-thread file I/O

### DIFF
--- a/app/src/main/java/com/sriniketh/prose/files/FileSourceImpl.kt
+++ b/app/src/main/java/com/sriniketh/prose/files/FileSourceImpl.kt
@@ -4,14 +4,18 @@ import android.content.Context
 import android.net.Uri
 import androidx.core.content.FileProvider.getUriForFile
 import com.sriniketh.core_platform.FileSource
+import com.sriniketh.core_platform.dagger.IoDispatcher
 import com.sriniketh.core_platform.logTag
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
 class FileSourceImpl @Inject constructor(
-    @ApplicationContext private val appContext: Context
+    @ApplicationContext private val appContext: Context,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : FileSource {
 
     override fun createNewFile(fileName: String): Uri {
@@ -21,18 +25,18 @@ class FileSourceImpl @Inject constructor(
         return contentUri
     }
 
-    override fun writeToFile(fileName: String, content: String): Uri {
+    override suspend fun writeToFile(fileName: String, content: String): Uri = withContext(ioDispatcher) {
         val file = File(appContext.cacheDir, fileName)
         file.writeText(content)
         val contentUri = getFileProviderUri(file)
         Timber.d("${this.logTag()}: Wrote file $contentUri")
-        return contentUri
+        contentUri
     }
 
-    override fun deleteFile(uri: Uri): Boolean {
+    override suspend fun deleteFile(uri: Uri): Boolean = withContext(ioDispatcher) {
         val result = appContext.contentResolver.delete(uri, null, null)
         Timber.d("${this.logTag()}: Deleted rows $result")
-        return result > 0
+        result > 0
     }
 
     private fun getFileProviderUri(file: File): Uri {

--- a/core-data/src/main/java/com/sriniketh/core_data/di/DataModule.kt
+++ b/core-data/src/main/java/com/sriniketh/core_data/di/DataModule.kt
@@ -4,6 +4,7 @@ import com.sriniketh.core_data.BooksRepository
 import com.sriniketh.core_data.BooksRepositoryImpl
 import com.sriniketh.core_data.HighlightsRepository
 import com.sriniketh.core_data.HighlightsRepositoryImpl
+import com.sriniketh.core_platform.dagger.IoDispatcher
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -28,5 +29,6 @@ object DataModule {
 
     @Provides
     @Singleton
+    @IoDispatcher
     fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
 }

--- a/core-data/src/main/java/com/sriniketh/core_data/usecases/DeleteFileUseCase.kt
+++ b/core-data/src/main/java/com/sriniketh/core_data/usecases/DeleteFileUseCase.kt
@@ -7,5 +7,5 @@ import javax.inject.Inject
 class DeleteFileUseCase @Inject constructor(
     private val fileSource: FileSource
 ) {
-    operator fun invoke(uri: Uri): Boolean = fileSource.deleteFile(uri)
+    suspend operator fun invoke(uri: Uri): Boolean = fileSource.deleteFile(uri)
 }

--- a/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeFileSource.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/fakes/FakeFileSource.kt
@@ -21,7 +21,7 @@ class FakeFileSource : FileSource {
 		return mockUri
 	}
 
-	override fun writeToFile(fileName: String, content: String): Uri {
+	override suspend fun writeToFile(fileName: String, content: String): Uri {
 		if (shouldWriteToFileFail) {
 			throw IOException("Failed to write file")
 		}
@@ -32,7 +32,7 @@ class FakeFileSource : FileSource {
 		return mockUri
 	}
 
-	override fun deleteFile(uri: Uri): Boolean {
+	override suspend fun deleteFile(uri: Uri): Boolean {
 		deletedUris.add(uri)
 		return !shouldDeleteFail
 	}

--- a/core-data/src/test/java/com/sriniketh/core_data/usecases/DeleteFileUseCaseTest.kt
+++ b/core-data/src/test/java/com/sriniketh/core_data/usecases/DeleteFileUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.sriniketh.core_data.usecases
 
 import com.sriniketh.core_data.fakes.FakeFileSource
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -11,7 +12,7 @@ class DeleteFileUseCaseTest {
 	private val deleteFileUseCase = DeleteFileUseCase(fileSource)
 
 	@Test
-	fun `when invoked then deletes file using file source`() {
+	fun `when invoked then deletes file using file source`() = runTest {
 		val file = fileSource.createNewFile("test.jpg")
 		val result = deleteFileUseCase(file)
 		assertTrue(result)
@@ -19,7 +20,7 @@ class DeleteFileUseCaseTest {
 	}
 
 	@Test
-	fun `when file source fails to delete file then returns false`() {
+	fun `when file source fails to delete file then returns false`() = runTest {
 		fileSource.shouldDeleteFail = true
 		val file = fileSource.createNewFile("test.jpg")
 		val result = deleteFileUseCase(file)

--- a/core-platform/src/main/java/com/sriniketh/core_platform/FileSource.kt
+++ b/core-platform/src/main/java/com/sriniketh/core_platform/FileSource.kt
@@ -4,6 +4,6 @@ import android.net.Uri
 
 interface FileSource {
     fun createNewFile(fileName: String): Uri
-    fun writeToFile(fileName: String, content: String): Uri
-    fun deleteFile(uri: Uri): Boolean
+    suspend fun writeToFile(fileName: String, content: String): Uri
+    suspend fun deleteFile(uri: Uri): Boolean
 }

--- a/core-platform/src/main/java/com/sriniketh/core_platform/dagger/IoDispatcher.kt
+++ b/core-platform/src/main/java/com/sriniketh/core_platform/dagger/IoDispatcher.kt
@@ -1,0 +1,7 @@
+package com.sriniketh.core_platform.dagger
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,7 +140,7 @@ Hilt wires everything. Conventions:
 |-------------|------------------|
 | [`NetworkModule`](../core-network/src/main/java/com/sriniketh/prose/core_network/di/NetworkModule.kt) | `Retrofit`/`BooksApi` (singleton), `BooksRemoteDataSource` |
 | [`DatabaseModule`](../core-db/src/main/java/com/sriniketh/core_db/dagger/DatabaseModule.kt) | `BookDatabase` (singleton), `BookDao`, `HighlightDao` |
-| [`DataModule`](../core-data/src/main/java/com/sriniketh/core_data/di/DataModule.kt) | `BooksRepository`, `HighlightsRepository`, IO `CoroutineDispatcher` |
+| [`DataModule`](../core-data/src/main/java/com/sriniketh/core_data/di/DataModule.kt) | `BooksRepository`, `HighlightsRepository`, `@IoDispatcher`-qualified `CoroutineDispatcher` |
 | [`PlatformModule`](../core-platform/src/main/java/com/sriniketh/core_platform/dagger/PlatformModule.kt) | `DateTimeSource` |
 | [`AppModule`](../app/src/main/java/com/sriniketh/prose/dagger/AppModule.kt) | `FileSource` → `FileSourceImpl` |
 | [`TextAnalysisModule`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/dagger/TextAnalysisModule.kt) | `TextAnalyzer` → `TextAnalyzerImpl` |
@@ -149,7 +149,13 @@ Hilt wires everything. Conventions:
 > in `app` ([`FileSourceImpl`](../app/src/main/java/com/sriniketh/prose/files/FileSourceImpl.kt)),
 > because the implementation needs `FileProvider` + the app's `packageName`/authority. `core-data`
 > depends only on the interface. `DateTimeSource`, by contrast, is implemented and bound inside
-> `core-platform`.
+> `core-platform`. `FileSource.writeToFile`/`deleteFile` are `suspend` and dispatch onto the
+> `@IoDispatcher` `CoroutineDispatcher` inside `FileSourceImpl`, so callers never do disk I/O on Main.
+
+> **Note — `@IoDispatcher` qualifier.** The qualifier annotation itself lives in `core-platform`
+> ([`IoDispatcher`](../core-platform/src/main/java/com/sriniketh/core_platform/dagger/IoDispatcher.kt))
+> so every module that depends on `core-platform` can inject the dispatcher, even ones (like `app`)
+> that don't depend on `core-data`, which is where the binding is provided.
 
 The application class [`ProseApplication`](../app/src/main/java/com/sriniketh/prose/ProseApplication.kt)
 is `@HiltAndroidApp` and plants a Timber `DebugTree` in debug builds.

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -140,12 +140,20 @@ Steps ([`CaptureAndCropImageViewModel`](../feature-addhighlight/src/main/java/co
 [`CaptureAndCropImageScreen`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreen.kt)):
 1. **CaptureImage** — a `TakePicture` activity-result launcher writes the photo into the temp
    FileProvider URI. On cancel/failure the screen calls `goBack()`.
-2. **CropImage** — `CropImageScreen` (Cropify) lets the user crop; `onImageCropped()` advances state.
+2. **CropImage** — entering this state kicks off `GetRotatedBitmapUseCase(imageUri)` (EXIF-aware
+   rotation, off Main via `@IoDispatcher`); [`CropImageScreen`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CropImageScreen.kt)
+   (Cropify) then lets the user crop. A successful crop calls `viewModel.onImageCropped(bitmap)`,
+   which writes the bitmap back to the temp URI via `SaveCroppedImageUseCase` (also off Main) and
+   only then advances state. If the write fails, or Cropify fails to load the image at all
+   (`onFailedToLoadImage`), the ViewModel emits `CaptureAndCropImageEffect.ShowMessage` (a snackbar)
+   instead of silently advancing — the user stays on the crop screen and can retry.
 3. **ImageCapturedAndCropped** — the screen calls `onImageCaptured(uri)`, which URL-encodes the URI
    and navigates to `save_highlight_from_uri/{bookId}/{encodedUri}`.
 4. **Cleanup** — `onCleared()` deletes the temp file *unless* the flow completed
-   (`ImageCapturedAndCropped`), so abandoned captures don't leak files. The completed file is handed
-   off to the next screen, which deletes it after OCR.
+   (`ImageCapturedAndCropped`), so abandoned captures don't leak files. The delete runs suspend, off
+   Main, on a short-lived `CoroutineScope(SupervisorJob() + ioDispatcher)` (since `viewModelScope` is
+   already cancelled by the time `onCleared()` runs). The completed file is handed off to the next
+   screen, which deletes it after OCR.
 
 ### 5b. OCR & save
 
@@ -169,7 +177,9 @@ Details:
 - [`TextAnalyzer`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/TextAnalyzer.kt)
   wraps the callback-based ML Kit recognizer in `suspendCancellableCoroutine` and closes the
   recognizer on cancellation. OCR runs fully on-device.
-- OCR failure → `image_processing_failure` snackbar; the temp file is deleted in `finally` either way.
+- OCR failure → `image_processing_failure` snackbar; the temp file is deleted in `finally` either way
+  (wrapped in `withContext(NonCancellable)` since `DeleteFileUseCase`/`FileSource.deleteFile` are
+  `suspend` and must still run even if the coroutine was cancelled).
 - A new highlight gets a random `UUID` and the current formatted timestamp.
 
 ### 5c. Edit an existing highlight

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -167,7 +167,12 @@ Two screens: search and book detail.
 ### `feature-addhighlight`
 The most involved feature (camera, crop, OCR, save).
 - [`CaptureAndCropImageViewModel`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageViewModel.kt)
-  — temp-file lifecycle + capture→crop state machine.
+  — temp-file lifecycle + capture→crop state machine. Loading the rotated bitmap and writing the
+  cropped bitmap back to the temp file both run off Main via
+  [`GetRotatedBitmapUseCase`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/GetRotatedBitmapUseCase.kt)
+  and [`SaveCroppedImageUseCase`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/SaveCroppedImageUseCase.kt)
+  (both dispatch on the `@IoDispatcher`-qualified `CoroutineDispatcher`). A failed crop/load surfaces
+  a `CaptureAndCropImageEffect.ShowMessage` instead of silently advancing to the next screen.
 - [`EditAndSaveHighlightViewModel`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightViewModel.kt)
   — runs OCR, edits, and persists.
 - [`TextAnalyzer`](../feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/TextAnalyzer.kt)

--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreenTest.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreenTest.kt
@@ -67,7 +67,9 @@ class CaptureAndCropImageScreenTest {
 			is CaptureAndCropImageScreenState.CropImage -> {
 				CropImageScreen(
 					imageUri = screenState.imageUri,
-					onImageCropped = onImageCropped
+					rotatedBitmap = null,
+					onImageCropped = { onImageCropped() },
+					onImageLoadFailed = {}
 				)
 			}
 

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreen.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreen.kt
@@ -1,14 +1,23 @@
 package com.sriniketh.feature_addhighlight
 
+import android.graphics.Bitmap
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalResources
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.launch
 
 @Composable
 fun CaptureAndCropImageScreen(
@@ -18,6 +27,12 @@ fun CaptureAndCropImageScreen(
     goBack: () -> Unit
 ) {
     val captureAndCropImageScreenState: CaptureAndCropImageScreenState by viewModel.screenState.collectAsStateWithLifecycle()
+    val rotatedBitmap: Bitmap? by viewModel.rotatedBitmap.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val resources = LocalResources.current
+    val scope = rememberCoroutineScope()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
     val cameraLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.TakePicture(),
         onResult = { success ->
@@ -28,6 +43,18 @@ fun CaptureAndCropImageScreen(
             }
         }
     )
+
+    LaunchedEffect(Unit) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.effects.collect { effect ->
+                when (effect) {
+                    is CaptureAndCropImageEffect.ShowMessage -> scope.launch {
+                        snackbarHostState.showSnackbar(resources.getString(effect.messageRes))
+                    }
+                }
+            }
+        }
+    }
 
     when (val screenState = captureAndCropImageScreenState) {
         is CaptureAndCropImageScreenState.CaptureImage -> {
@@ -40,7 +67,10 @@ fun CaptureAndCropImageScreen(
             CropImageScreen(
                 modifier = modifier,
                 imageUri = screenState.imageUri,
-                onImageCropped = { viewModel.onImageCropped() }
+                rotatedBitmap = rotatedBitmap,
+                onImageCropped = { croppedBitmap -> viewModel.onImageCropped(croppedBitmap) },
+                onImageLoadFailed = { viewModel.onImageLoadFailed() },
+                snackbarHostState = snackbarHostState
             )
         }
 

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageViewModel.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageViewModel.kt
@@ -1,22 +1,36 @@
 package com.sriniketh.feature_addhighlight
 
+import android.graphics.Bitmap
 import android.net.Uri
+import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.sriniketh.core_data.usecases.CreateTempImageFileUseCase
 import com.sriniketh.core_data.usecases.DeleteFileUseCase
+import com.sriniketh.core_platform.dagger.IoDispatcher
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CaptureAndCropImageViewModel @Inject constructor(
     private val createTempImageFileUseCase: CreateTempImageFileUseCase,
     private val deleteFileUseCase: DeleteFileUseCase,
-    private val savedStateHandle: SavedStateHandle
+    private val getRotatedBitmapUseCase: GetRotatedBitmapUseCase,
+    private val saveCroppedImageUseCase: SaveCroppedImageUseCase,
+    private val savedStateHandle: SavedStateHandle,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
 
     private val imageUri: Uri by lazy {
@@ -29,17 +43,44 @@ class CaptureAndCropImageViewModel @Inject constructor(
         MutableStateFlow(CaptureAndCropImageScreenState.CaptureImage(imageUri))
     internal val screenState: StateFlow<CaptureAndCropImageScreenState> = _screenState.asStateFlow()
 
+    private val _rotatedBitmap = MutableStateFlow<Bitmap?>(null)
+    internal val rotatedBitmap: StateFlow<Bitmap?> = _rotatedBitmap.asStateFlow()
+
+    private val _effects = Channel<CaptureAndCropImageEffect>(Channel.BUFFERED)
+    internal val effects: Flow<CaptureAndCropImageEffect> = _effects.receiveAsFlow()
+
     internal fun onImageCaptured() {
         _screenState.update { CaptureAndCropImageScreenState.CropImage(imageUri) }
+        loadRotatedBitmap()
     }
 
-    internal fun onImageCropped() {
-        _screenState.update { CaptureAndCropImageScreenState.ImageCapturedAndCropped(imageUri) }
+    private fun loadRotatedBitmap() {
+        viewModelScope.launch {
+            val bitmap = getRotatedBitmapUseCase(imageUri)
+            _rotatedBitmap.update { bitmap }
+        }
+    }
+
+    internal fun onImageCropped(croppedBitmap: Bitmap) {
+        viewModelScope.launch {
+            val saved = saveCroppedImageUseCase(imageUri, croppedBitmap)
+            if (saved) {
+                _screenState.update { CaptureAndCropImageScreenState.ImageCapturedAndCropped(imageUri) }
+            } else {
+                _effects.trySend(CaptureAndCropImageEffect.ShowMessage(R.string.crop_image_error_message))
+            }
+        }
+    }
+
+    internal fun onImageLoadFailed() {
+        _effects.trySend(CaptureAndCropImageEffect.ShowMessage(R.string.crop_image_error_message))
     }
 
     override fun onCleared() {
         if (screenState.value !is CaptureAndCropImageScreenState.ImageCapturedAndCropped) {
-            deleteFileUseCase(imageUri)
+            CoroutineScope(SupervisorJob() + ioDispatcher).launch {
+                deleteFileUseCase(imageUri)
+            }
             savedStateHandle.remove<Uri>("imageUri")
         }
         super.onCleared()
@@ -50,4 +91,8 @@ internal sealed interface CaptureAndCropImageScreenState {
     data class CaptureImage(val imageUri: Uri) : CaptureAndCropImageScreenState
     data class CropImage(val imageUri: Uri) : CaptureAndCropImageScreenState
     data class ImageCapturedAndCropped(val imageUri: Uri) : CaptureAndCropImageScreenState
+}
+
+internal sealed interface CaptureAndCropImageEffect {
+    data class ShowMessage(@StringRes val messageRes: Int) : CaptureAndCropImageEffect
 }

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CropImageScreen.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/CropImageScreen.kt
@@ -13,33 +13,28 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import io.moyuru.cropify.Cropify
 import io.moyuru.cropify.rememberCropifyState
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun CropImageScreen(
     modifier: Modifier = Modifier,
     imageUri: Uri,
-    onImageCropped: () -> Unit,
-    ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    rotatedBitmap: Bitmap?,
+    onImageCropped: (Bitmap) -> Unit,
+    onImageLoadFailed: () -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
 ) {
-    val context = LocalContext.current
     val cropifyState = rememberCropifyState()
-    val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(
         modifier = modifier.testTag("AddHighlightCropImageScreen"),
         floatingActionButton = {
@@ -64,12 +59,6 @@ internal fun CropImageScreen(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { contentPadding ->
 
-        val rotatedBitmapState = produceState<Bitmap?>(initialValue = null, key1 = imageUri) {
-            value = withContext(ioDispatcher) {
-                ImageRotater.getRotatedBitmap(context, imageUri)
-            }
-        }
-        val rotatedBitmap = rotatedBitmapState.value
         if (rotatedBitmap != null) {
             Cropify(
                 modifier = Modifier
@@ -78,11 +67,7 @@ internal fun CropImageScreen(
                 bitmap = rotatedBitmap.asImageBitmap(),
                 state = cropifyState,
                 onImageCropped = { imageBitmap ->
-                    val croppedBitmap = imageBitmap.asAndroidBitmap()
-                    context.contentResolver.openOutputStream(imageUri)?.use { outputStream ->
-                        croppedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
-                    }
-                    onImageCropped()
+                    onImageCropped(imageBitmap.asAndroidBitmap())
                 }
             )
         } else {
@@ -93,13 +78,9 @@ internal fun CropImageScreen(
                 uri = imageUri,
                 state = cropifyState,
                 onImageCropped = { imageBitmap ->
-                    val croppedBitmap = imageBitmap.asAndroidBitmap()
-                    context.contentResolver.openOutputStream(imageUri)?.use { outputStream ->
-                        croppedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
-                    }
-                    onImageCropped()
+                    onImageCropped(imageBitmap.asAndroidBitmap())
                 },
-                onFailedToLoadImage = { onImageCropped() }
+                onFailedToLoadImage = { onImageLoadFailed() }
             )
         }
     }

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightViewModel.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightViewModel.kt
@@ -12,6 +12,7 @@ import com.sriniketh.core_models.book.Highlight
 import com.sriniketh.core_platform.DateTimeSource
 import com.sriniketh.core_platform.logTag
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,6 +21,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
@@ -65,7 +67,9 @@ class EditAndSaveHighlightViewModel @Inject constructor(
                 }
                 _effects.trySend(EditAndSaveHighlightEffect.ShowMessage(R.string.image_processing_failure_error_message))
             } finally {
-                deleteFileUseCase(uri)
+                withContext(NonCancellable) {
+                    deleteFileUseCase(uri)
+                }
             }
         }
     }

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/GetRotatedBitmapUseCase.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/GetRotatedBitmapUseCase.kt
@@ -1,0 +1,19 @@
+package com.sriniketh.feature_addhighlight
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import com.sriniketh.core_platform.dagger.IoDispatcher
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class GetRotatedBitmapUseCase @Inject constructor(
+    @ApplicationContext private val appContext: Context,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) {
+    suspend operator fun invoke(imageUri: Uri): Bitmap? = withContext(ioDispatcher) {
+        ImageRotater.getRotatedBitmap(appContext, imageUri)
+    }
+}

--- a/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/SaveCroppedImageUseCase.kt
+++ b/feature-addhighlight/src/main/java/com/sriniketh/feature_addhighlight/SaveCroppedImageUseCase.kt
@@ -1,0 +1,20 @@
+package com.sriniketh.feature_addhighlight
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import com.sriniketh.core_platform.dagger.IoDispatcher
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class SaveCroppedImageUseCase @Inject constructor(
+    @ApplicationContext private val appContext: Context,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) {
+    suspend operator fun invoke(imageUri: Uri, croppedBitmap: Bitmap): Boolean = withContext(ioDispatcher) {
+        val outputStream = appContext.contentResolver.openOutputStream(imageUri) ?: return@withContext false
+        outputStream.use { croppedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, it) }
+    }
+}

--- a/feature-addhighlight/src/main/res/values/strings.xml
+++ b/feature-addhighlight/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="done_button_label">Done</string>
     <string name="save_highlight_error_message">Error saving highlight.</string>
     <string name="image_processing_failure_error_message">Error processing image for highlight text.</string>
+    <string name="crop_image_error_message">Error cropping image. Please try again.</string>
 </resources>

--- a/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageViewModelTest.kt
+++ b/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageViewModelTest.kt
@@ -1,0 +1,156 @@
+package com.sriniketh.feature_addhighlight
+
+import android.content.ContentResolver
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
+import app.cash.turbine.test
+import com.sriniketh.core_data.usecases.CreateTempImageFileUseCase
+import com.sriniketh.core_data.usecases.DeleteFileUseCase
+import com.sriniketh.feature_addhighlight.fakes.FakeFileSource
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.OutputStream
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CaptureAndCropImageViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var fakeFileSource: FakeFileSource
+    private lateinit var createTempImageFileUseCase: CreateTempImageFileUseCase
+    private lateinit var deleteFileUseCase: DeleteFileUseCase
+    private lateinit var getRotatedBitmapUseCase: GetRotatedBitmapUseCase
+    private lateinit var saveCroppedImageUseCase: SaveCroppedImageUseCase
+    private lateinit var contentResolver: ContentResolver
+    private lateinit var context: Context
+    private lateinit var viewModel: CaptureAndCropImageViewModel
+    private lateinit var imageUri: Uri
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        fakeFileSource = FakeFileSource()
+        createTempImageFileUseCase = CreateTempImageFileUseCase(fakeFileSource)
+        deleteFileUseCase = DeleteFileUseCase(fakeFileSource)
+        contentResolver = mockk()
+        context = mockk()
+        every { context.contentResolver } returns contentResolver
+        getRotatedBitmapUseCase = GetRotatedBitmapUseCase(context, testDispatcher)
+        saveCroppedImageUseCase = SaveCroppedImageUseCase(context, testDispatcher)
+
+        viewModel = CaptureAndCropImageViewModel(
+            createTempImageFileUseCase = createTempImageFileUseCase,
+            deleteFileUseCase = deleteFileUseCase,
+            getRotatedBitmapUseCase = getRotatedBitmapUseCase,
+            saveCroppedImageUseCase = saveCroppedImageUseCase,
+            savedStateHandle = SavedStateHandle(),
+            ioDispatcher = testDispatcher
+        )
+        imageUri = (viewModel.screenState.value as CaptureAndCropImageScreenState.CaptureImage).imageUri
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `when image cropped and write succeeds then state transitions to captured and cropped`() = runTest {
+        val outputStream = mockk<OutputStream>(relaxed = true)
+        every { contentResolver.openOutputStream(imageUri) } returns outputStream
+        val croppedBitmap = mockk<Bitmap>()
+        every { croppedBitmap.compress(any(), any(), any()) } returns true
+
+        viewModel.onImageCropped(croppedBitmap)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.screenState.value is CaptureAndCropImageScreenState.ImageCapturedAndCropped)
+    }
+
+    @Test
+    fun `when image cropped and output stream is null then failure effect is emitted instead of silently succeeding`() =
+        runTest {
+            every { contentResolver.openOutputStream(imageUri) } returns null
+            val croppedBitmap = mockk<Bitmap>()
+
+            viewModel.effects.test {
+                viewModel.onImageCropped(croppedBitmap)
+
+                assertEquals(
+                    CaptureAndCropImageEffect.ShowMessage(R.string.crop_image_error_message),
+                    awaitItem()
+                )
+            }
+
+            assertFalse(viewModel.screenState.value is CaptureAndCropImageScreenState.ImageCapturedAndCropped)
+        }
+
+    @Test
+    fun `when image fails to load then failure effect is emitted instead of silently succeeding`() = runTest {
+        viewModel.effects.test {
+            viewModel.onImageLoadFailed()
+
+            assertEquals(
+                CaptureAndCropImageEffect.ShowMessage(R.string.crop_image_error_message),
+                awaitItem()
+            )
+        }
+
+        assertFalse(viewModel.screenState.value is CaptureAndCropImageScreenState.ImageCapturedAndCropped)
+    }
+
+    @Test
+    fun `when image captured then rotated bitmap is loaded using injected dispatcher`() = runTest {
+        every { contentResolver.openInputStream(imageUri) } returns null
+
+        viewModel.onImageCaptured()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.screenState.value is CaptureAndCropImageScreenState.CropImage)
+        assertNull(viewModel.rotatedBitmap.value)
+    }
+
+    @Test
+    fun `when cleared before crop completes then temp file is deleted using injected dispatcher`() = runTest {
+        val store = ViewModelStore()
+        store.put("captureAndCropImageViewModel", viewModel)
+
+        store.clear()
+        advanceUntilIdle()
+
+        assertTrue(fakeFileSource.deletedUris.contains(imageUri))
+    }
+
+    @Test
+    fun `when cleared after crop completes then temp file is not deleted`() = runTest {
+        val outputStream = mockk<OutputStream>(relaxed = true)
+        every { contentResolver.openOutputStream(imageUri) } returns outputStream
+        val croppedBitmap = mockk<Bitmap>()
+        every { croppedBitmap.compress(any(), any(), any()) } returns true
+        viewModel.onImageCropped(croppedBitmap)
+        advanceUntilIdle()
+
+        val store = ViewModelStore()
+        store.put("captureAndCropImageViewModel", viewModel)
+        store.clear()
+        advanceUntilIdle()
+
+        assertFalse(fakeFileSource.deletedUris.contains(imageUri))
+    }
+}

--- a/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/fakes/FakeFileSource.kt
+++ b/feature-addhighlight/src/test/java/com/sriniketh/feature_addhighlight/fakes/FakeFileSource.kt
@@ -13,11 +13,11 @@ class FakeFileSource : FileSource {
         return mockk<Uri>()
     }
 
-    override fun writeToFile(fileName: String, content: String): Uri {
+    override suspend fun writeToFile(fileName: String, content: String): Uri {
         return Uri.parse("content://com.test.fileProvider/cache/$fileName")
     }
 
-    override fun deleteFile(uri: Uri): Boolean {
+    override suspend fun deleteFile(uri: Uri): Boolean {
         deletedUris.add(uri)
         return !shouldDeleteFail
     }

--- a/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/fakes/FakeFileSource.kt
+++ b/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/fakes/FakeFileSource.kt
@@ -13,11 +13,11 @@ class FakeFileSource : FileSource {
         return mockUri
     }
 
-    override fun writeToFile(fileName: String, content: String): Uri {
+    override suspend fun writeToFile(fileName: String, content: String): Uri {
         val mockUri = mockk<Uri>()
         every { mockUri.toString() } returns "content://com.test.fileProvider/cache/$fileName"
         return mockUri
     }
 
-    override fun deleteFile(uri: Uri): Boolean = true
+    override suspend fun deleteFile(uri: Uri): Boolean = true
 }


### PR DESCRIPTION
## Summary
Three Medium findings bundled into one PR because they touch the same code:
1. **Silent crop failures (§2.4.3)** — a null `openOutputStream` silently discarded the cropped bitmap while still calling `onImageCropped()` (OCR ran on the uncropped photo), and a load failure was routed into the success continuation.
2. **Main-thread disk I/O (§2.5.3)** — `FileSourceImpl` ran synchronously on Main from every caller; `croppedBitmap.compress(...)` ran in a plain Compose callback.
3. **Dead dispatcher binding (§2.5.4)** — an unqualified, uninjected `@Singleton CoroutineDispatcher` in `DataModule`; `CropImageScreen.kt` hardcoded `Dispatchers.IO` instead.

## Fix
`CropImageScreen` is now a dumb composable with no bitmap/file I/O — `CaptureAndCropImageViewModel.onImageCropped()`/`onImageLoadFailed()` route failures to a `ShowMessage` effect instead of silently proceeding. `FileSource.writeToFile`/`deleteFile` are now `suspend`, dispatched via a new `@IoDispatcher` qualifier (added in `core-platform`, since the annotation needs to be visible from `app` across `implementation`-only module edges). New `GetRotatedBitmapUseCase`/`SaveCroppedImageUseCase` replace the composable's raw calls. `DeleteFileUseCase` is now suspend; `EditAndSaveHighlightViewModel`'s finally-cleanup wraps it in `withContext(NonCancellable)` so it still runs on cancellation without swallowing the propagating exception. `CaptureAndCropImageViewModel.onCleared()` fires its delete on a standalone `CoroutineScope(SupervisorJob() + ioDispatcher)` since `viewModelScope` is already cancelled by the time `onCleared()` runs.

## Test plan
- New `CaptureAndCropImageViewModelTest` (6 cases) using `StandardTestDispatcher` to verify the injected dispatcher is honored.
- Updated fakes/tests across `core-data`, `feature-addhighlight`, `feature-viewhighlights`.
- `./gradlew test` (all modules) + `:feature-addhighlight:connectedDebugAndroidTest` on Pixel_8 API 34 — all green.
- `docs/architecture.md`, `docs/modules.md`, `docs/flows.md` updated per AGENTS.md's sync rule.

## Known non-blocking notes from review
- The `onCleared()` fire-and-forget delete scope has no timeout — if the delete ever hung, nothing would cancel it (low risk: it's a fast local `ContentResolver.delete()` on a cache-dir file). Worth a bounded `withTimeoutOrNull` in a follow-up.
- `GetRotatedBitmapUseCase` wraps `ImageRotater` as it exists on `main` today — a separate, independent PR (§2.5.2, unbounded bitmap decode) also touches `ImageRotater` and will need reconciling with this one at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)