### PR TITLE
[chore] drop redundant -Xannotation-default-target compiler arg

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/sriniketh/prose/buildlogic/KotlinConfig.kt
+++ b/build-logic/convention/src/main/kotlin/com/sriniketh/prose/buildlogic/KotlinConfig.kt
@@ -2,17 +2,10 @@ package com.sriniketh.prose.buildlogic
 
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal fun Project.configureKotlin() {
     extensions.configure<KotlinBaseExtension> {
         jvmToolchain(libs.version("jvmToolchainVersion").toInt())
-    }
-    tasks.withType<KotlinCompile>().configureEach {
-        compilerOptions {
-            freeCompilerArgs.add("-Xannotation-default-target=param-property")
-        }
     }
 }

--- a/docs/convention-plugins.md
+++ b/docs/convention-plugins.md
@@ -268,18 +268,11 @@ the shared `kotlin { }` configuration for both Android and JVM modules:
 extensions.configure<KotlinBaseExtension> {
 	jvmToolchain(libs.version("jvmToolchainVersion").toInt())
 }
-tasks.withType<KotlinCompile>().configureEach {
-	compilerOptions {
-		freeCompilerArgs.add("-Xannotation-default-target=param-property")
-	}
-}
 ```
 
 `KotlinBaseExtension` is the common supertype of the Android and JVM Kotlin extensions, and Gradle's
 `getByType` matches on subtype — so one function serves `prose.android.library` and
-`prose.jvm.library` both. `tasks.withType<KotlinCompile>` replaced the old root `subprojects { }`
-block, and does match AGP 9's built-in Kotlin compile tasks even though no Kotlin Android plugin is
-applied.
+`prose.jvm.library` both.
 
 **[`AndroidConfig.kt`](../build-logic/convention/src/main/kotlin/com/sriniketh/prose/buildlogic/AndroidConfig.kt)** —
 the shared `android { }` configuration, taking a plain `CommonExtension` so it serves both `app` and
@@ -489,7 +482,7 @@ To prove a dependency change did what you meant, diff the resolved graph:
 
 ## Known remaining cleanups
 
-Three pieces of dead or redundant configuration survive the migration. Each is a small, independent
+Two pieces of dead or redundant configuration survive the migration. Each is a small, independent
 follow-up.
 
 **1. The Safe Args catalog entry is unused.** The plugin was dropped from the root
@@ -508,16 +501,6 @@ and `core-network` (`BOOKS_API_KEY`, `DEBUG`) read a `BuildConfig` class. Moving
 `buildFeatures.buildConfig = true` out of `configureAndroidCommon` into the application plugin, and
 adding it explicitly to `core-network/build.gradle.kts`, removes a generated class and a compile
 task from seven modules.
-
-**3. `-Xannotation-default-target=param-property` is redundant on Kotlin 2.4.** Every compile task
-now warns:
-
-```
-w: The argument '-Xannotation-default-target=param-property' is redundant for the current language version 2.4.
-```
-
-It is already the default. The `tasks.withType<KotlinCompile>` block in `KotlinConfig.kt` can be
-deleted, leaving `configureKotlin()` as just the toolchain call.
 
 ---
 


### PR DESCRIPTION
## Summary

`KotlinConfig.kt` added `-Xannotation-default-target=param-property` to every Kotlin compile task's `freeCompilerArgs`. On Kotlin 2.4 (this repo's toolchain) that value is already the default, so every compile task emitted:

```
w: The argument '-Xannotation-default-target=param-property' is redundant for the current language version 2.4.
```

Confirmed firsthand before making any change:

```
$ ./gradlew :core-models:compileKotlin --rerun
...
> Task :core-models:compileKotlin
w: The argument '-Xannotation-default-target=param-property' is redundant for the current language version 2.4.
...
BUILD SUCCESSFUL in 893ms
```

## Change

- Removed the `tasks.withType<KotlinCompile>().configureEach { ... }` block from `KotlinConfig.kt`, leaving `configureKotlin()` as just the `jvmToolchain(...)` call, and dropped the now-unused `KotlinCompile`/`withType` imports.
- Updated `docs/convention-plugins.md`:
  - `KotlinConfig.kt` code sample in "Shared helpers" now matches the trimmed function, and the prose after it no longer references the removed `tasks.withType<KotlinCompile>` block.
  - Removed item 3 ("`-Xannotation-default-target=param-property` is redundant on Kotlin 2.4") from "Known remaining cleanups" since it's now done, and updated the section's intro count from "Three pieces" to "Two pieces". The two remaining items (Safe Args catalog entry, `buildConfig` scoping) are unrelated and untouched.

## Verification

```
./gradlew -p build-logic :convention:compileKotlin   # BUILD SUCCESSFUL, no warning
./gradlew assembleDebug                              # BUILD SUCCESSFUL, no warning (grepped full log)
./gradlew test                                       # BUILD SUCCESSFUL
```

The redundancy warning no longer appears anywhere in the `assembleDebug` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)