### PR TITLE
Scope BuildConfig generation to app and core-network only

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/sriniketh/prose/buildlogic/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/sriniketh/prose/buildlogic/AndroidApplicationConventionPlugin.kt
@@ -12,6 +12,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
         extensions.configure<ApplicationExtension> {
             configureAndroidCommon(this)
             defaultConfig.targetSdk = libs.version("targetSdkVersion").toInt()
+            buildFeatures.buildConfig = true
         }
         configureKotlin()
     }

--- a/build-logic/convention/src/main/kotlin/com/sriniketh/prose/buildlogic/AndroidConfig.kt
+++ b/build-logic/convention/src/main/kotlin/com/sriniketh/prose/buildlogic/AndroidConfig.kt
@@ -19,7 +19,5 @@ internal fun Project.configureAndroidCommon(extension: CommonExtension) {
                 "proguard-rules.pro"
             )
         }
-
-        buildFeatures.buildConfig = true
     }
 }

--- a/core-network/build.gradle.kts
+++ b/core-network/build.gradle.kts
@@ -23,6 +23,10 @@ android {
     defaultConfig {
         buildConfigField("String", "BOOKS_API_KEY", apikeyProperties["BOOKS_API_KEY"] as String)
     }
+
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/docs/convention-plugins.md
+++ b/docs/convention-plugins.md
@@ -38,7 +38,7 @@ build-logic/
     └── src/main/kotlin/com/sriniketh/prose/buildlogic/
         ├── ProjectExtensions.kt         # version-catalog access helper
         ├── KotlinConfig.kt              # shared Kotlin config (toolchain, compiler args)
-        ├── AndroidConfig.kt             # shared Android config (SDKs, ProGuard, buildConfig)
+        ├── AndroidConfig.kt             # shared Android config (SDKs, ProGuard)
         ├── AndroidApplicationConventionPlugin.kt
         ├── AndroidLibraryConventionPlugin.kt
         ├── AndroidComposeConventionPlugin.kt
@@ -147,11 +147,14 @@ pluginManager.apply("com.android.application")
 extensions.configure<ApplicationExtension> {
 	configureAndroidCommon(this)
 	defaultConfig.targetSdk = libs.version("targetSdkVersion").toInt()
+	buildFeatures.buildConfig = true
 }
 configureKotlin()
 ```
 
-Structurally identical to the library plugin, plus `targetSdk` (an application-only property).
+Structurally identical to the library plugin, plus `targetSdk` (an application-only property) and
+`buildFeatures.buildConfig = true` — `app` is the only module that gets `BuildConfig` generation for
+free; every other module opts in per-module (`core-network` does, in its own `build.gradle.kts`).
 `applicationId`, `versionCode`, and `versionName` deliberately stay in `app/build.gradle.kts` —
 they are identity, not convention.
 
@@ -302,14 +305,17 @@ internal fun Project.configureAndroidCommon(extension: CommonExtension) {
 				"proguard-rules.pro"
 			)
 		}
-
-		buildFeatures.buildConfig = true
 	}
 }
 ```
 
 The property-access style (`defaultConfig.apply { }`, `buildTypes.getByName(…)`) is required, not
 stylistic — see [constraint 3](#3-commonextension-exposes-defaultconfig-and-buildtypes-as-properties-only).
+
+`buildConfig` generation is **not** part of this shared helper — only `app` and `core-network` read
+a generated `BuildConfig` class, so `prose.android.application` sets
+`buildFeatures.buildConfig = true` itself, and `core-network/build.gradle.kts` opts in explicitly.
+The other seven Android modules get no `BuildConfig` class or compile task at all.
 
 ---
 
@@ -321,7 +327,7 @@ stylistic — see [constraint 3](#3-commonextension-exposes-defaultconfig-and-bu
 | `core-models` | `prose.jvm.library` | — |
 | `core-platform` | `prose.android.library`, `prose.android.hilt` | — |
 | `core-db` | `prose.android.library`, `prose.android.hilt` | `ksp { arg("room.schemaLocation", …) }` |
-| `core-network` | `prose.android.library`, `prose.android.hilt`, `kotlin.serialization` | `apikey.properties` loading, `buildConfigField`, `optIn` |
+| `core-network` | `prose.android.library`, `prose.android.hilt`, `kotlin.serialization` | `apikey.properties` loading, `buildFeatures.buildConfig = true`, `buildConfigField`, `optIn` |
 | `core-data` | `prose.android.library`, `prose.android.hilt`, `kotlin.serialization` | — |
 | `core-design` | `prose.android.library`, `prose.android.compose` | — |
 | `feature-bookshelf` | `prose.android.feature` | — |
@@ -489,7 +495,7 @@ To prove a dependency change did what you meant, diff the resolved graph:
 
 ## Known remaining cleanups
 
-Three pieces of dead or redundant configuration survive the migration. Each is a small, independent
+Two pieces of dead or redundant configuration survive the migration. Each is a small, independent
 follow-up.
 
 **1. The Safe Args catalog entry is unused.** The plugin was dropped from the root
@@ -503,13 +509,7 @@ find . -type d -name navigation -not -path "*/build/*"    # no results
 `android-navigation-safe-args-plugin-version` and the `android-navigation-safe-args` plugin alias
 are still in `gradle/libs.versions.toml` and can go.
 
-**2. `buildConfig = true` is enabled for every Android module.** Only `app` (`BuildConfig.DEBUG`)
-and `core-network` (`BOOKS_API_KEY`, `DEBUG`) read a `BuildConfig` class. Moving
-`buildFeatures.buildConfig = true` out of `configureAndroidCommon` into the application plugin, and
-adding it explicitly to `core-network/build.gradle.kts`, removes a generated class and a compile
-task from seven modules.
-
-**3. `-Xannotation-default-target=param-property` is redundant on Kotlin 2.4.** Every compile task
+**2. `-Xannotation-default-target=param-property` is redundant on Kotlin 2.4.** Every compile task
 now warns:
 
 ```


### PR DESCRIPTION
## What

`buildFeatures.buildConfig = true` was set for every Android module inside `configureAndroidCommon` in `AndroidConfig.kt`, generating a `BuildConfig` class and compile task for all 9 Android modules. Only `app` (`BuildConfig.DEBUG`) and `core-network` (`BOOKS_API_KEY`, `DEBUG`) actually read a generated `BuildConfig` class.

## Changes

- Removed `buildFeatures.buildConfig = true` from `configureAndroidCommon` (`AndroidConfig.kt`).
- Added it explicitly to `AndroidApplicationConventionPlugin`'s `ApplicationExtension` block, so `app` keeps the same behavior via the convention plugin.
- Added `buildFeatures.buildConfig = true` directly to `core-network/build.gradle.kts` — `core-network` applies `prose.android.library`, not `prose.android.application`, so it needs its own opt-in.
- Updated `docs/convention-plugins.md`: refreshed the `AndroidConfig.kt` and `AndroidApplicationConventionPlugin.kt` code samples, noted the buildConfig opt-in in the "Which module applies what" table, and removed the now-resolved item from "Known remaining cleanups" (renumbered the remaining item and fixed the intro count).

## Why

The other 7 Android modules (`core-platform`, `core-db`, `core-data`, `core-design`, `feature-bookshelf`, `feature-searchbooks`, `feature-viewhighlights`, `feature-addhighlight`) never reference a generated `BuildConfig` class. This was the second item in `docs/convention-plugins.md`'s "Known remaining cleanups" list — removing it drops a generated class and compile task from those 7 modules.

## Verification

```
./gradlew -p build-logic :convention:compileKotlin   # success
./gradlew assembleDebug                              # success
./gradlew test                                       # success (incl. core-network, which reads BuildConfig.BOOKS_API_KEY in tests)
```

Confirmed via `grep -rn "BuildConfig"` that only `app` and `core-network` reference `BuildConfig` anywhere in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)