### PR TITLE
Add Stop hook to remind about docs drift on structural changes

### DIFF
--- a/.claude/hooks/check-docs-drift.sh
+++ b/.claude/hooks/check-docs-drift.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Stop hook: reminds the agent to update docs/*.md when structural files
+# changed without a docs update, per the rules in AGENTS.md.
+set -uo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" 2>/dev/null || exit 0
+
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+BASE_REF=""
+for ref in main origin/main; do
+  if git rev-parse --verify "$ref" >/dev/null 2>&1; then
+    BASE_REF="$ref"
+    break
+  fi
+done
+[ -n "$BASE_REF" ] || exit 0
+
+STATE_FILE=".claude/.docs-reminder-state"
+
+MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "$BASE_REF")
+
+COMMITTED=$(git diff --name-only "$MERGE_BASE"...HEAD 2>/dev/null || true)
+UNCOMMITTED=$(git status --porcelain --untracked-files=all 2>/dev/null | awk '{print $2}')
+CHANGED=$(printf '%s\n%s\n' "$COMMITTED" "$UNCOMMITTED" | sort -u | grep -v '^$' || true)
+
+if [ -z "$CHANGED" ]; then
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+STRUCTURAL=$(printf '%s\n' "$CHANGED" | grep -E \
+  -e '(^|/)build\.gradle\.kts$' \
+  -e '^settings\.gradle\.kts$' \
+  -e '^build-logic/' \
+  -e '(^|/)(di|dagger)/.*\.kt$' \
+  -e '^app/src/main/java/com/sriniketh/prose/Navigation\.kt$' \
+  || true)
+
+if [ -z "$STRUCTURAL" ]; then
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+DOCS=$(printf '%s\n' "$CHANGED" | grep -E '^docs/.*\.md$' || true)
+
+if [ -n "$DOCS" ]; then
+  rm -f "$STATE_FILE"
+  exit 0
+fi
+
+HASH=$(printf '%s' "$STRUCTURAL" | shasum | awk '{print $1}')
+
+mkdir -p .claude
+if [ -f "$STATE_FILE" ] && [ "$(cat "$STATE_FILE")" = "$HASH" ]; then
+  exit 0
+fi
+echo "$HASH" > "$STATE_FILE"
+
+REASON="AGENTS.md requires updating docs/*.md in the same change set when structural files change (Gradle module files, Hilt DI wiring, Navigation.kt, or convention plugins under build-logic/). These changed files look structural, but no docs/*.md file was touched:
+$STRUCTURAL
+
+Update the relevant file under docs/ (architecture.md, modules.md, convention-plugins.md, flows.md, or the fast facts in README.md — see AGENTS.md for which applies) before finishing, or proceed if you've judged none of the docs rules apply to this change."
+
+jq -n --arg reason "$REASON" '{
+  decision: "block",
+  reason: $reason,
+  hookSpecificOutput: {
+    hookEventName: "Stop",
+    additionalContext: $reason
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-docs-drift.sh\"",
+            "timeout": 15,
+            "statusMessage": "Checking docs stayed in sync with structural changes..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ lint/outputs/
 lint/tmp/
 # lint/reports/
 .worktrees/
+
+# Claude Code hook state
+.claude/.docs-reminder-state


### PR DESCRIPTION
## What
Adds a project-level Stop hook (`.claude/settings.json` + `.claude/hooks/check-docs-drift.sh`) that fires whenever Claude Code tries to finish a turn on this repo.

## How it works
- Diffs the current branch against `main` (merge-base) plus any uncommitted/untracked working-tree changes.
- Flags files matching AGENTS.md's structural triggers: `*/build.gradle.kts`, `settings.gradle.kts`, anything under `build-logic/`, `*/di/**.kt` or `*/dagger/**.kt`, and `Navigation.kt`.
- If any match and no `docs/*.md` file is in the same change set, blocks the stop and feeds back a reason pointing at which doc (per AGENTS.md) likely needs updating.
- Debounces via a gitignored `.claude/.docs-reminder-state` hash file — reminds once per distinct drift state instead of looping forever, and clears itself once docs are touched or nothing structural remains.

## Why
AGENTS.md already documents when `docs/` must be updated in the same change set, but nothing enforced it — docs could silently drift. This turns that written rule into an automatic reminder without hard-blocking legitimate no-docs-needed changes indefinitely.

## Testing
Pipe-tested the script directly against synthetic scenarios (structural change without docs → blocks with valid JSON; same state again → silent; docs present → silent), validated `.claude/settings.json` with `jq -e`, and ran the exact wired command via `$CLAUDE_PROJECT_DIR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)