### PR TITLE
Close feature-bookshelf coverage gaps in ViewModel and screen tests

### DIFF
--- a/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
+++ b/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
@@ -1,5 +1,8 @@
 package com.sriniketh.feature_bookshelf
 
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -10,6 +13,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -181,6 +185,73 @@ class BookshelfScreenTest {
 
         composeTestRule.onNodeWithTag("BookItem_test-book-id").performClick()
         assertTrue(calledBookId == bookId)
+    }
+
+    @Test
+    fun whenMultipleBooksArePresentThenAllBookTitlesAreDisplayed() {
+        val books = persistentListOf(
+            createTestBookUIState(id = "book-1", title = "First Book Title"),
+            createTestBookUIState(id = "book-2", title = "Second Book Title")
+        )
+        val uiState = BookshelfUIState(books = books)
+
+        composeTestRule.setContent {
+            AppTheme {
+                Bookshelf(
+                    uiState = uiState,
+                    goToSearch = {},
+                    goToHighlight = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("First Book Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Second Book Title").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenMultipleBooksArePresentThenClickingSecondBookItemCallsGoToHighlightWithCorrectId() {
+        val books = persistentListOf(
+            createTestBookUIState(id = "book-1", title = "First Book Title"),
+            createTestBookUIState(id = "book-2", title = "Second Book Title")
+        )
+        val uiState = BookshelfUIState(books = books)
+        var calledBookId: String? = null
+
+        composeTestRule.setContent {
+            AppTheme {
+                Bookshelf(
+                    uiState = uiState,
+                    goToSearch = {},
+                    goToHighlight = { calledBookId = it }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("BookItem_book-2").performClick()
+        assertEquals("book-2", calledBookId)
+    }
+
+    @Test
+    fun whenSnackbarHostStateShowsMessageThenMessageIsDisplayed() {
+        val uiState = BookshelfUIState()
+
+        composeTestRule.setContent {
+            AppTheme {
+                val snackbarHostState = remember { SnackbarHostState() }
+                LaunchedEffect(Unit) {
+                    snackbarHostState.showSnackbar("Book added to shelf")
+                }
+                Bookshelf(
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    goToSearch = {},
+                    goToHighlight = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Book added to shelf").assertIsDisplayed()
     }
 
     @Test

--- a/feature-bookshelf/src/test/java/com/sriniketh/feature_bookshelf/BookshelfViewModelTest.kt
+++ b/feature-bookshelf/src/test/java/com/sriniketh/feature_bookshelf/BookshelfViewModelTest.kt
@@ -2,6 +2,8 @@ package com.sriniketh.feature_bookshelf
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.sriniketh.core_models.book.Book
+import com.sriniketh.core_models.book.BookInfo
 import com.sriniketh.feature_bookshelf.fakes.FakeBooksRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -137,4 +139,81 @@ class BookshelfViewModelTest {
 
         assertEquals(false, savedStateHandle.get<Boolean>(BOOKSHELF_SHOW_ADDED_MESSAGE))
     }
+
+    @Test
+    fun `when book added flag is false then no added message effect is emitted`() = runTest {
+        val savedStateHandle = SavedStateHandle(
+            mapOf(BOOKSHELF_SHOW_ADDED_MESSAGE to false)
+        )
+        val viewModel = BookshelfViewModel(fakeBooksRepository, savedStateHandle)
+
+        viewModel.effects.test {
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `when book added flag is set again after being cleared then message is emitted again`() =
+        runTest {
+            val savedStateHandle = SavedStateHandle(
+                mapOf(BOOKSHELF_SHOW_ADDED_MESSAGE to true)
+            )
+            val viewModel = BookshelfViewModel(fakeBooksRepository, savedStateHandle)
+
+            viewModel.effects.test {
+                assertEquals(
+                    BookshelfEffect.ShowMessage(R.string.book_added_to_shelf_message),
+                    awaitItem()
+                )
+
+                savedStateHandle[BOOKSHELF_SHOW_ADDED_MESSAGE] = true
+
+                assertEquals(
+                    BookshelfEffect.ShowMessage(R.string.book_added_to_shelf_message),
+                    awaitItem()
+                )
+            }
+        }
+
+    @Test
+    fun `when repository emits an updated book list then ui state reflects the new list`() =
+        runTest {
+            val viewModel = BookshelfViewModel(fakeBooksRepository, SavedStateHandle())
+            val secondBook = Book(
+                id = "second-id",
+                info = BookInfo(
+                    title = "Second Title",
+                    subtitle = null,
+                    authors = listOf("Author A", "Author B"),
+                    thumbnailLink = null,
+                    publisher = null,
+                    publishedDate = null,
+                    description = null,
+                    pageCount = null,
+                    averageRating = null,
+                    ratingsCount = null
+                )
+            )
+
+            viewModel.bookshelfUIState.test {
+                skipItems(2)
+
+                val loadedState = awaitItem()
+                val firstBookId = loadedState.books[0].id
+                assertEquals(1, loadedState.books.size)
+
+                fakeBooksRepository.savedBooksFlow.value = Result.success(
+                    fakeBooksRepository.savedBooksFlow.value.getOrThrow() + secondBook
+                )
+
+                val updatedState = awaitItem()
+                assertEquals(2, updatedState.books.size)
+                assertEquals(firstBookId, updatedState.books[0].id)
+                val secondBookUiState = updatedState.books[1]
+                assertEquals("second-id", secondBookUiState.id)
+                assertEquals("Second Title", secondBookUiState.title)
+                assertEquals(persistentListOf("Author A", "Author B"), secondBookUiState.authors)
+                assertEquals(null, secondBookUiState.thumbnailLink)
+            }
+        }
 }

--- a/feature-bookshelf/src/test/java/com/sriniketh/feature_bookshelf/fakes/FakeBooksRepository.kt
+++ b/feature-bookshelf/src/test/java/com/sriniketh/feature_bookshelf/fakes/FakeBooksRepository.kt
@@ -5,6 +5,7 @@ import com.sriniketh.core_models.book.Book
 import com.sriniketh.core_models.book.BookInfo
 import com.sriniketh.core_models.search.BookSearch
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 
 class FakeBooksRepository : BooksRepository {
@@ -28,6 +29,8 @@ class FakeBooksRepository : BooksRepository {
 		)
 	)
 
+	val savedBooksFlow = MutableStateFlow<Result<List<Book>>>(Result.success(listOf(fakeBook)))
+
 	override suspend fun searchForBooks(searchQuery: String): Result<BookSearch> {
 		return Result.success(BookSearch(items = listOf(fakeBook)))
 	}
@@ -48,7 +51,7 @@ class FakeBooksRepository : BooksRepository {
 		return if (shouldGetAllSavedBooksFromDbThrowException) {
 			flowOf(Result.failure(RuntimeException("Get all books failed")))
 		} else {
-			flowOf(Result.success(listOf(fakeBook)))
+			savedBooksFlow
 		}
 	}
 


### PR DESCRIPTION
## Summary

feature-bookshelf already had BookshelfViewModelTest (6 tests) and BookshelfScreenTest (11 tests) with decent behavioral coverage but low JaCoCo unit-test coverage. This PR adds tests for concrete gaps found by cross-referencing BookshelfViewModel.kt / BookshelfScreen.kt against the existing suites, without duplicating what's already covered.

## ViewModel gaps closed (`BookshelfViewModelTest.kt`, +3 tests)

- `when book added flag is false then no added message effect is emitted` — the `if (showAddedMessage)` false branch was never explicitly asserted (only exercised as a side effect of other tests).
- `when book added flag is set again after being cleared then message is emitted again` — verifies the message effect re-fires on a second true→false→true cycle of `BOOKSHELF_SHOW_ADDED_MESSAGE`, not just once.
- `when repository emits an updated book list then ui state reflects the new list` — the fake previously emitted a single value via `flowOf`, so the ViewModel's ongoing `collect` on a live-updating db flow was untested. Also exercises `Book -> BookUIState` mapping for a book with multiple authors and a null thumbnail link (previously only single-author/non-null-thumbnail was covered).

### `fakes/FakeBooksRepository.kt`

`getAllSavedBooksFromDb()` now returns a `MutableStateFlow` (`savedBooksFlow`) instead of a one-shot `flowOf`, so tests can push additional emissions to simulate a live db flow. The exception-flag path is unchanged.

## Screen gaps closed (`BookshelfScreenTest.kt`, +3 tests)

- `whenMultipleBooksArePresentThenAllBookTitlesAreDisplayed` — prior tests only ever rendered a single-item list.
- `whenMultipleBooksArePresentThenClickingSecondBookItemCallsGoToHighlightWithCorrectId` — verifies the `LazyColumn` `key = { it.id }` click wiring picks the right item, not just item index 0.
- `whenSnackbarHostStateShowsMessageThenMessageIsDisplayed` — the `SnackbarHost` in the `Scaffold` was never exercised by any test.

## What I deliberately did not test

- `BookshelfScreen` (the `hiltViewModel()`-wired composable) and its effect→snackbar wiring end-to-end — that would require Hilt instrumentation test setup (`@HiltAndroidTest`/`HiltAndroidRule`), which this module doesn't have and is out of scope here. The effect-emission logic is fully covered at the ViewModel unit-test level, and the `Bookshelf` composable's snackbar rendering is now covered directly by passing a `SnackbarHostState` with a message already queued.
- `AsyncImage`/Coil thumbnail rendering — not meaningfully testable without a real network/image pipeline, and not business logic.

## Verification

```
./gradlew :feature-bookshelf:testDebugUnitTest :feature-bookshelf:compileDebugAndroidTestKotlin
```

Result: BUILD SUCCESSFUL. `BookshelfViewModelTest` now runs 9 tests (0 failures). `compileDebugAndroidTestKotlin` compiles cleanly with the 3 new UI tests (14 total in `BookshelfScreenTest`); `connectedDebugAndroidTest` was **not** run locally (no device available) — CI runs it on a real API 34 emulator per `.github/workflows/build.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)