### PR TITLE
Close remaining test gaps in feature-viewhighlights

### DIFF
--- a/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
+++ b/feature-viewhighlights/src/androidTest/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreenTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme
 import kotlinx.collections.immutable.persistentListOf
@@ -308,6 +309,118 @@ class ViewHighlightsScreenTest {
 
         composeTestRule.onNodeWithText("Edited highlight text").assertIsDisplayed()
         composeTestRule.onNodeWithText("Original highlight text").assertDoesNotExist()
+    }
+
+    @Test
+    fun whenShareButtonIsClickedThenOnExportHighlightsEventIsTriggered() {
+        val bookId = "test-book-id"
+        val uiState = ViewHighlightsUIState()
+        var actionTriggered: ViewHighlightsAction? = null
+
+        composeTestRule.setContent {
+            AppTheme {
+                ViewHighlights(
+                    uiState = uiState,
+                    bookId = bookId,
+                    onAction = { actionTriggered = it }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Share highlights").performClick()
+        assertTrue(actionTriggered is ViewHighlightsAction.OnExportHighlights)
+        assertEquals(bookId, (actionTriggered as ViewHighlightsAction.OnExportHighlights).bookId)
+    }
+
+    @Test
+    fun whenCopyMenuItemIsClickedThenDropdownMenuIsDismissed() {
+        val highlights = persistentListOf(createTestHighlightUIState())
+        val uiState = ViewHighlightsUIState(highlights = highlights)
+
+        composeTestRule.setContent {
+            AppTheme {
+                ViewHighlights(
+                    uiState = uiState,
+                    bookId = "test-book-id",
+                    onAction = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Options Menu").performClick()
+        composeTestRule.onNodeWithTag("HighlightMenuItemCopy").performClick()
+
+        composeTestRule.onNodeWithText("Copy").assertDoesNotExist()
+    }
+
+    @Test
+    fun whenHighlightTextExceedsLimitThenTruncatedTextIsDisplayedWithEllipsis() {
+        val longText = "A".repeat(300)
+        val truncatedText = "A".repeat(250) + " ..."
+        val highlights = persistentListOf(createTestHighlightUIState(text = longText))
+        val uiState = ViewHighlightsUIState(highlights = highlights)
+
+        composeTestRule.setContent {
+            AppTheme {
+                ViewHighlights(
+                    uiState = uiState,
+                    bookId = "test-book-id",
+                    onAction = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(truncatedText).assertIsDisplayed()
+        composeTestRule.onNodeWithText(longText).assertDoesNotExist()
+    }
+
+    @Test
+    fun whenTruncatedHighlightIsClickedThenFullTextIsDisplayed() {
+        val longText = "B".repeat(300)
+        val truncatedText = "B".repeat(250) + " ..."
+        val highlights = persistentListOf(createTestHighlightUIState(text = longText))
+        val uiState = ViewHighlightsUIState(highlights = highlights)
+
+        composeTestRule.setContent {
+            AppTheme {
+                ViewHighlights(
+                    uiState = uiState,
+                    bookId = "test-book-id",
+                    onAction = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(truncatedText).performClick()
+
+        composeTestRule.onNodeWithText(longText).assertIsDisplayed()
+        composeTestRule.onNodeWithText(truncatedText).assertDoesNotExist()
+    }
+
+    @Test
+    fun whenScrolledPastSecondItemThenFloatingActionButtonIsHidden() {
+        val highlights = persistentListOf(
+            *Array(20) { index ->
+                createTestHighlightUIState(id = "id-$index", text = "Highlight $index")
+            }
+        )
+        val uiState = ViewHighlightsUIState(highlights = highlights)
+
+        composeTestRule.setContent {
+            AppTheme {
+                ViewHighlights(
+                    uiState = uiState,
+                    bookId = "test-book-id",
+                    onAction = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Add highlight").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("HighlightsList").performScrollToIndex(15)
+
+        composeTestRule.onNodeWithContentDescription("Add highlight").assertDoesNotExist()
     }
 
     private fun createTestHighlightUIState(

--- a/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
+++ b/feature-viewhighlights/src/main/java/com/sriniketh/feature_viewhighlights/ViewHighlightsScreen.kt
@@ -226,7 +226,8 @@ internal fun ViewHighlights(
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(contentPadding),
+                    .padding(contentPadding)
+                    .testTag("HighlightsList"),
                 state = lazyListState
             ) {
                 items(uiState.highlights, key = { it.id }) { highlightUiState ->

--- a/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModelTest.kt
+++ b/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/ViewHighlightsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.sriniketh.feature_viewhighlights
 
 import app.cash.turbine.test
 import com.sriniketh.core_data.usecases.ExportHighlightsUseCase
+import com.sriniketh.core_models.book.Highlight
 import com.sriniketh.feature_viewhighlights.fakes.FakeBooksRepository
 import com.sriniketh.feature_viewhighlights.fakes.FakeFileSource
 import com.sriniketh.feature_viewhighlights.fakes.FakeHighlightsRepository
@@ -119,6 +120,43 @@ class ViewHighlightsViewModelTest {
             awaitItem()
             val errorState = awaitItem()
             assertTrue(errorState.highlights.isEmpty())
+        }
+    }
+
+    @Test
+    fun `when getHighlights succeeds with multiple highlights then sorts by saved timestamp`() = runTest {
+        val bookId = "test-book-id"
+        fakeHighlightsRepository.shouldGetAllHighlightsForBookFromDbThrowException = false
+        fakeHighlightsRepository.highlightsToReturn = listOf(
+            Highlight(
+                id = "later",
+                bookId = bookId,
+                text = "later text",
+                savedOnTimestamp = "2023-03-01 10:00 AM"
+            ),
+            Highlight(
+                id = "earlier",
+                bookId = bookId,
+                text = "earlier text",
+                savedOnTimestamp = "2023-01-01 10:00 AM"
+            ),
+            Highlight(
+                id = "middle",
+                bookId = bookId,
+                text = "middle text",
+                savedOnTimestamp = "2023-02-01 10:00 AM"
+            )
+        )
+
+        viewModel.highlightsUIStateFlow.test {
+            awaitItem()
+
+            viewModel.getHighlights(bookId)
+
+            awaitItem()
+            val finalState = awaitItem()
+
+            assertEquals(listOf("earlier", "middle", "later"), finalState.highlights.map { it.id })
         }
     }
 

--- a/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/fakes/FakeHighlightsRepository.kt
+++ b/feature-viewhighlights/src/test/java/com/sriniketh/feature_viewhighlights/fakes/FakeHighlightsRepository.kt
@@ -19,6 +19,8 @@ class FakeHighlightsRepository : HighlightsRepository {
         savedOnTimestamp = "2023-01-01 12:00 PM"
     )
 
+    var highlightsToReturn: List<Highlight> = listOf(fakeHighlight)
+
     override suspend fun insertHighlightIntoDb(highlight: Highlight): Result<Unit> {
         return Result.success(Unit)
     }
@@ -32,7 +34,7 @@ class FakeHighlightsRepository : HighlightsRepository {
         if (shouldGetAllHighlightsForBookFromDbThrowException) {
             emit(Result.failure(RuntimeException("Get all highlights failed")))
         } else {
-            emit(Result.success(listOf(fakeHighlight)))
+            emit(Result.success(highlightsToReturn))
         }
     }
 


### PR DESCRIPTION
## Summary

`ViewHighlightsViewModel` and `ViewHighlightsScreen` already had solid test files, but a close read against the production code surfaced a handful of genuinely untested behaviors. This PR closes those gaps.

### Unit tests (`ViewHighlightsViewModelTest.kt`)
- Added `when getHighlights succeeds with multiple highlights then sorts by saved timestamp` — the existing fake only ever returned a single highlight, so `highlights.sortedBy { it.savedOnTimestamp }` was never actually exercised with out-of-order input. Extended `FakeHighlightsRepository` with a configurable `highlightsToReturn` list (defaults to the original single fake highlight, so no existing test's behavior changes) to make this controllable.

### UI tests (`ViewHighlightsScreenTest.kt`)
- `whenShareButtonIsClickedThenOnExportHighlightsEventIsTriggered` — the top-bar share/export icon button had no test at all.
- `whenCopyMenuItemIsClickedThenDropdownMenuIsDismissed` — the "Copy" dropdown item (clipboard write + menu dismiss) was untested.
- `whenHighlightTextExceedsLimitThenTruncatedTextIsDisplayedWithEllipsis` and `whenTruncatedHighlightIsClickedThenFullTextIsDisplayed` — the 250-char truncation + tap-to-expand logic in the highlight row was entirely uncovered.
- `whenScrolledPastSecondItemThenFloatingActionButtonIsHidden` — the `derivedStateOf` driving FAB visibility off `firstVisibleItemIndex` had no scroll-based test. Added a `testTag("HighlightsList")` on the `LazyColumn` (mirroring the existing `SearchResultsList` pattern in feature-searchbooks) so the test can drive `performScrollToIndex`.

### What I deliberately did not add
- No test for `OnCameraPermissionGranted`/`OnEditHighlight` hitting the ViewModel's `else -> Unit` branch beyond the existing `OnBackPressed` case — same code path, already fully branch-covered, so it would just be duplication.
- No test for the outer `ViewHighlightsScreen` composable (the `hiltViewModel()` + effect-collection wiring) — this module's androidTest setup has no Hilt test rule, and adding one is out of scope for a coverage-focused change.
- No FAB permission-launcher flow test — clicking it launches the real Android runtime-permission dialog, which isn't something `createComposeRule` can drive meaningfully.
- Did not "fix" a possible bug I noticed: on a successful delete, `isLoading` is never reset back to `false` (only the failure path resets it) and the list isn't refreshed after delete. Left as-is since fixing production behavior is out of scope for a test-coverage PR — flagging here for visibility.

## Verification
- `./gradlew :feature-viewhighlights:testDebugUnitTest` — green, 15 unit tests (was 14), 0 failures.
- `./gradlew :feature-viewhighlights:compileDebugAndroidTestKotlin` — compiles clean.
- Did not run `connectedDebugAndroidTest` locally (no device available) — CI runs it on a real API 34 emulator per `.github/workflows/build.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)