### PR TITLE
Make Codecov failures strict, add PR coverage comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
             feature-viewhighlights/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml,
             feature-addhighlight/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
           flags: unittests
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   ui-tests:
     runs-on: ubuntu-latest
@@ -152,4 +152,4 @@ jobs:
             core-platform/build/reports/coverage/androidTest/debug/connected/report.xml,
             app/build/reports/coverage/androidTest/debug/connected/report.xml
           flags: androidtests
-          fail_ci_if_error: false
+          fail_ci_if_error: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,14 @@ coverage:
     project: off
     patch: off
 
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: false
+
 ignore:
   - "**/build/**"
   - "**/R.java"


### PR DESCRIPTION
Follow-up to #170, now that real coverage data has uploaded successfully.

- `fail_ci_if_error: true` on both upload steps (unit + instrumented) — a future upload failure will now actually fail CI instead of being silently swallowed.
- Added Codecov's ["show project coverage changes on the pull request comment"](https://docs.codecov.com/docs/common-recipe-list#show-project-coverage-changes-on-the-pull-request-comment) recipe to `codecov.yml` — PRs get a comment with diff/flags/files coverage plus overall project coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)