### PR TITLE
Test: cover BookshelfScreen's ViewModel wrapper

### DIFF
--- a/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
+++ b/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/BookshelfScreenTest.kt
@@ -9,11 +9,14 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.lifecycle.SavedStateHandle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme
+import com.sriniketh.feature_bookshelf.fakes.FakeBooksRepository
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -269,6 +272,110 @@ class BookshelfScreenTest {
         }
 
         composeTestRule.onNodeWithText("Test Book Title").assertDoesNotExist()
+    }
+
+    @Test
+    fun whenBookshelfScreenIsDisplayedThenBooksFromViewModelAreShown() {
+        val fakeBooksRepository = FakeBooksRepository()
+        val viewModel = BookshelfViewModel(fakeBooksRepository, SavedStateHandle())
+
+        composeTestRule.setContent {
+            AppTheme {
+                BookshelfScreen(
+                    viewModel = viewModel,
+                    goToSearch = {},
+                    goToHighlight = {}
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Test Title").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenBookAddedFlagIsSetThenBookshelfScreenShowsAddedSnackbarMessage() {
+        val fakeBooksRepository = FakeBooksRepository()
+        val savedStateHandle = SavedStateHandle(mapOf(BOOKSHELF_SHOW_ADDED_MESSAGE to true))
+        val viewModel = BookshelfViewModel(fakeBooksRepository, savedStateHandle)
+
+        composeTestRule.setContent {
+            AppTheme {
+                BookshelfScreen(
+                    viewModel = viewModel,
+                    goToSearch = {},
+                    goToHighlight = {}
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Book has been added to shelf!").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenLoadingBooksFailsThenBookshelfScreenShowsErrorSnackbarMessage() {
+        val fakeBooksRepository = FakeBooksRepository().apply {
+            shouldGetAllSavedBooksFromDbThrowException = true
+        }
+        val viewModel = BookshelfViewModel(fakeBooksRepository, SavedStateHandle())
+
+        composeTestRule.setContent {
+            AppTheme {
+                BookshelfScreen(
+                    viewModel = viewModel,
+                    goToSearch = {},
+                    goToHighlight = {}
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Error retrieving saved books.").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenFabIsClickedOnBookshelfScreenThenGoToSearchLambdaIsInvoked() {
+        val fakeBooksRepository = FakeBooksRepository()
+        val viewModel = BookshelfViewModel(fakeBooksRepository, SavedStateHandle())
+        var goToSearchCalled = false
+
+        composeTestRule.setContent {
+            AppTheme {
+                BookshelfScreen(
+                    viewModel = viewModel,
+                    goToSearch = { goToSearchCalled = true },
+                    goToHighlight = {}
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("search for a book button").performClick()
+        assertTrue(goToSearchCalled)
+    }
+
+    @Test
+    fun whenBookItemIsClickedOnBookshelfScreenThenGoToHighlightLambdaIsInvokedWithBookId() {
+        val fakeBooksRepository = FakeBooksRepository()
+        val viewModel = BookshelfViewModel(fakeBooksRepository, SavedStateHandle())
+        var calledBookId: String? = null
+
+        composeTestRule.setContent {
+            AppTheme {
+                BookshelfScreen(
+                    viewModel = viewModel,
+                    goToSearch = {},
+                    goToHighlight = { calledBookId = it }
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        assertNull(calledBookId)
+
+        composeTestRule.onNodeWithTag("BookItem_test-id").performClick()
+        assertEquals("test-id", calledBookId)
     }
 
     private fun createTestBookUIState(

--- a/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/fakes/FakeBooksRepository.kt
+++ b/feature-bookshelf/src/androidTest/java/com/sriniketh/feature_bookshelf/fakes/FakeBooksRepository.kt
@@ -1,0 +1,64 @@
+package com.sriniketh.feature_bookshelf.fakes
+
+import com.sriniketh.core_data.BooksRepository
+import com.sriniketh.core_models.book.Book
+import com.sriniketh.core_models.book.BookInfo
+import com.sriniketh.core_models.search.BookSearch
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+
+class FakeBooksRepository : BooksRepository {
+
+    var shouldGetAllSavedBooksFromDbThrowException = false
+
+    private val fakeBook = Book(
+        id = "test-id",
+        info = BookInfo(
+            title = "Test Title",
+            subtitle = "Test Subtitle",
+            authors = listOf("Test Author"),
+            thumbnailLink = "test-thumbnail",
+            publisher = "Test Publisher",
+            publishedDate = "2023",
+            description = "Test Description",
+            pageCount = 200,
+            averageRating = 4.5,
+            ratingsCount = 100
+        )
+    )
+
+    val savedBooksFlow = MutableStateFlow<Result<List<Book>>>(Result.success(listOf(fakeBook)))
+
+    override suspend fun searchForBooks(searchQuery: String): Result<BookSearch> {
+        return Result.success(BookSearch(items = listOf(fakeBook)))
+    }
+
+    override suspend fun fetchBookInfo(volumeId: String): Result<Book> {
+        return Result.success(fakeBook)
+    }
+
+    override suspend fun insertBookIntoDb(book: Book): Result<Unit> {
+        return Result.success(Unit)
+    }
+
+    override suspend fun doesBookExistInDb(bookId: String): Boolean {
+        return false
+    }
+
+    override fun getAllSavedBooksFromDb(): Flow<Result<List<Book>>> {
+        return if (shouldGetAllSavedBooksFromDbThrowException) {
+            flowOf(Result.failure(RuntimeException("Get all books failed")))
+        } else {
+            savedBooksFlow
+        }
+    }
+
+    override suspend fun getBookByIdFromDb(bookId: String): Result<Book> {
+        return Result.success(fakeBook)
+    }
+
+    override suspend fun deleteBookFromDb(book: Book): Result<Unit> {
+        return Result.success(Unit)
+    }
+}


### PR DESCRIPTION
## Why

`BookshelfScreen.kt` sat at 55.3% line coverage (89/161) on Codecov — the weakest single-screen file outside `feature-addhighlight`. The existing suite (`BookshelfScreenTest.kt`) only ever called the internal `Bookshelf(uiState, ...)` composable directly. The public `BookshelfScreen(viewModel = hiltViewModel(), ...)` wrapper — which collects `uiState` from the ViewModel, collects its effects `Channel` via `repeatOnLifecycle`, and shows snackbar messages through `LocalResources.getString` — was never exercised, so its `LaunchedEffect`/effect-collection logic had zero coverage. That includes the `BOOKSHELF_SHOW_ADDED_MESSAGE` saved-state-handle flow that `app`'s `ProseAppScreen.kt` sets when returning from adding a book.

`BookshelfViewModel` is plain constructor-injected (`@Inject`, no Hilt needed to instantiate it per Google's testing guidance), and `BookshelfScreen` already accepts `viewModel` as a parameter, so this needed no Hilt test infrastructure and no production code changes — tests construct a real `BookshelfViewModel` backed by a small `androidTest`-local `FakeBooksRepository` (mirroring the existing `src/test` fake, which unit tests can't share across source sets) and render `BookshelfScreen` directly.

## What was added (`BookshelfScreenTest.kt`)

- Books loaded through the real ViewModel are rendered on screen
- `BOOKSHELF_SHOW_ADDED_MESSAGE = true` in the `SavedStateHandle` shows the "added to shelf" snackbar end-to-end
- A repository failure shows the error snackbar end-to-end
- FAB click on `BookshelfScreen` invokes `goToSearch`
- Book item click on `BookshelfScreen` invokes `goToHighlight` with the correct id

Plus `feature-bookshelf/src/androidTest/.../fakes/FakeBooksRepository.kt`, a copy of the unit-test fake for the `androidTest` source set.

## Coverage (measured locally via `createDebugAndroidTestCoverageReport`)

Device-only JaCoCo numbers (baseline differs slightly from Codecov's merged unit+instrumented 55.3%/89/161, since this task only measures the instrumented run):

| Metric | Before | After |
|---|---|---|
| Lines | 102/182 (56%) | 124/182 (68%) |
| Instructions | 49% | 71% |
| Branches | 38% | 69% |
| Methods | 12/32 | 20/32 |
| Classes | 4/8 | 8/8 |

All 18 instrumented tests (13 existing + 5 new) pass.

## Deliberately left out

- Scroll-triggered FAB visibility — the FAB in this composable has no scroll-based visibility logic, so there was nothing to test there.
- `@PreviewLightDark` functions — left uncovered per the parallel effort to exclude `@Preview` composables from coverage entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)