### PR TITLE
test: close feature-addhighlight coverage gaps (TextAnalyzer, ImageRotater, CaptureAndCropImageScreen, CropImageScreen, EditAndSaveHighlightScreen)

### DIFF
--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreenTest.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/CaptureAndCropImageScreenTest.kt
@@ -1,17 +1,25 @@
 package com.sriniketh.feature_addhighlight
 
+import android.graphics.Bitmap
+import android.graphics.Color
 import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.lifecycle.SavedStateHandle
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.sriniketh.core_design.ui.theme.AppTheme
+import com.sriniketh.feature_addhighlight.fakes.FakeFileSource
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
 
 @RunWith(AndroidJUnit4::class)
 class CaptureAndCropImageScreenTest {
@@ -20,6 +28,66 @@ class CaptureAndCropImageScreenTest {
 	val composeTestRule = createComposeRule()
 
 	private val mockUri = Uri.parse("content://test.jpg")
+
+	private fun createViewModel(fileSource: FakeFileSource = FakeFileSource()): CaptureAndCropImageViewModel =
+		CaptureAndCropImageViewModel(
+			fileSource = fileSource,
+			savedStateHandle = SavedStateHandle()
+		)
+
+	private fun writeValidImageUri(): Uri {
+		val context = InstrumentationRegistry.getInstrumentation().targetContext
+		val bitmap = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
+		bitmap.eraseColor(Color.BLUE)
+		val file = File(context.cacheDir, "capture_crop_test.png")
+		FileOutputStream(file).use { outputStream ->
+			bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+		}
+		return Uri.fromFile(file)
+	}
+
+	@Test
+	fun whenScreenStateIsCropImageThenRealScreenRendersCropImageScreen() {
+		val viewModel = createViewModel(FakeFileSource(uriToReturn = writeValidImageUri()))
+		viewModel.onImageCaptured()
+
+		composeTestRule.setContent {
+			AppTheme {
+				CaptureAndCropImageScreen(
+					viewModel = viewModel,
+					onImageCaptured = {},
+					goBack = {}
+				)
+			}
+		}
+
+		composeTestRule.waitForIdle()
+		composeTestRule.onNodeWithTag("AddHighlightCropImageScreen").assertIsDisplayed()
+	}
+
+	@Test
+	fun whenScreenStateIsImageCapturedAndCroppedThenRealScreenInvokesOnImageCaptured() {
+		val viewModel = createViewModel()
+		viewModel.onImageCaptured()
+		viewModel.onImageCropped()
+		var capturedUri: Uri? = null
+
+		composeTestRule.setContent {
+			AppTheme {
+				CaptureAndCropImageScreen(
+					viewModel = viewModel,
+					onImageCaptured = { capturedUri = it },
+					goBack = {}
+				)
+			}
+		}
+
+		composeTestRule.waitForIdle()
+		assertEquals(
+			(viewModel.screenState.value as CaptureAndCropImageScreenState.ImageCapturedAndCropped).imageUri,
+			capturedUri
+		)
+	}
 
 	@Test
 	fun whenCropImageStateIsDisplayedThenCropScreenIsShown() {

--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/CropImageScreenTest.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/CropImageScreenTest.kt
@@ -1,15 +1,24 @@
 package com.sriniketh.feature_addhighlight
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
 import android.net.Uri
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.sriniketh.core_design.ui.theme.AppTheme
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
 
 @RunWith(AndroidJUnit4::class)
 class CropImageScreenTest {
@@ -18,6 +27,17 @@ class CropImageScreenTest {
 	val composeTestRule = createComposeRule()
 
 	private val mockUri = Uri.parse("content://test.jpg")
+
+	private fun writeValidImageFile(fileName: String): Uri {
+		val context = InstrumentationRegistry.getInstrumentation().targetContext
+		val bitmap = Bitmap.createBitmap(120, 120, Bitmap.Config.ARGB_8888)
+		bitmap.eraseColor(Color.GREEN)
+		val file = File(context.cacheDir, fileName)
+		FileOutputStream(file).use { outputStream ->
+			bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+		}
+		return Uri.fromFile(file)
+	}
 
 	@Test
 	fun whenScreenIsDisplayedThenScaffoldIsShown() {
@@ -47,5 +67,48 @@ class CropImageScreenTest {
 
 		composeTestRule.waitForIdle()
 		composeTestRule.onNodeWithContentDescription("Done cropping button").assertIsDisplayed()
+	}
+
+	@Test
+	fun whenImageFailsToLoadThenOnImageCroppedIsInvoked() {
+		var onImageCroppedCalled = false
+
+		composeTestRule.setContent {
+			AppTheme {
+				CropImageScreen(
+					imageUri = mockUri,
+					onImageCropped = { onImageCroppedCalled = true }
+				)
+			}
+		}
+
+		composeTestRule.waitUntil(timeoutMillis = 10_000) { onImageCroppedCalled }
+		assertTrue(onImageCroppedCalled)
+	}
+
+	@Test
+	fun whenImageLoadsSuccessfullyAndCropFabIsClickedThenCroppedBitmapIsWrittenBackToUri() {
+		val imageUri = writeValidImageFile("crop_success_test.png")
+		var onImageCroppedCalled = false
+
+		composeTestRule.setContent {
+			AppTheme {
+				CropImageScreen(
+					imageUri = imageUri,
+					onImageCropped = { onImageCroppedCalled = true }
+				)
+			}
+		}
+
+		composeTestRule.waitForIdle()
+		composeTestRule.onNodeWithContentDescription("Done cropping button").performClick()
+		composeTestRule.waitUntil(timeoutMillis = 10_000) { onImageCroppedCalled }
+
+		assertTrue(onImageCroppedCalled)
+		val context = InstrumentationRegistry.getInstrumentation().targetContext
+		val croppedBitmap = context.contentResolver.openInputStream(imageUri)?.use {
+			BitmapFactory.decodeStream(it)
+		}
+		assertNotNull(croppedBitmap)
 	}
 }

--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreenTest.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/EditAndSaveHighlightScreenTest.kt
@@ -1,15 +1,22 @@
 package com.sriniketh.feature_addhighlight
 
+import android.net.Uri
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.sriniketh.core_data.usecases.FormatCurrentDateTimeUseCase
 import com.sriniketh.core_design.ui.theme.AppTheme
+import com.sriniketh.feature_addhighlight.fakes.FakeDateTimeSource
+import com.sriniketh.feature_addhighlight.fakes.FakeFileSource
+import com.sriniketh.feature_addhighlight.fakes.FakeHighlightsRepository
+import com.sriniketh.feature_addhighlight.fakes.FakeTextAnalyzer
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -21,6 +28,17 @@ class EditAndSaveHighlightScreenTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    private fun createViewModel(
+        textAnalyzer: FakeTextAnalyzer = FakeTextAnalyzer(),
+        highlightsRepository: FakeHighlightsRepository = FakeHighlightsRepository()
+    ): EditAndSaveHighlightViewModel = EditAndSaveHighlightViewModel(
+        dateTimeSource = FakeDateTimeSource(),
+        textAnalyzer = textAnalyzer,
+        highlightsRepository = highlightsRepository,
+        formatCurrentDateTimeUseCase = FormatCurrentDateTimeUseCase(),
+        fileSource = FakeFileSource()
+    )
 
     @Test
     fun whenUIStateIsLoadingThenProgressIndicatorIsDisplayed() {
@@ -201,5 +219,170 @@ class EditAndSaveHighlightScreenTest {
 
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithTag("AddHighlightTextField").assertIsDisplayed().assertIsEnabled()
+    }
+
+    @Test
+    fun whenCaptureFlowScreenIsDisplayedThenProcessedHighlightTextIsShown() {
+        val fakeTextAnalyzer = FakeTextAnalyzer().apply { textToReturn = "Recognized highlight text" }
+        val viewModel = createViewModel(textAnalyzer = fakeTextAnalyzer)
+
+        composeTestRule.setContent {
+            AppTheme {
+                EditAndSaveHighlightScreen(
+                    viewModel = viewModel,
+                    uri = Uri.parse("content://test.jpg"),
+                    bookId = "book-id",
+                    goBack = {}
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Recognized highlight text").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Recognized highlight text").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenCaptureFlowImageProcessingFailsThenErrorSnackbarIsShown() {
+        val fakeTextAnalyzer = FakeTextAnalyzer().apply { shouldThrowException = true }
+        val viewModel = createViewModel(textAnalyzer = fakeTextAnalyzer)
+
+        composeTestRule.setContent {
+            AppTheme {
+                EditAndSaveHighlightScreen(
+                    viewModel = viewModel,
+                    uri = Uri.parse("content://test.jpg"),
+                    bookId = "book-id",
+                    goBack = {}
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Error processing image for highlight text.")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun whenCaptureFlowSaveSucceedsThenGoBackIsInvoked() {
+        val fakeTextAnalyzer = FakeTextAnalyzer().apply { textToReturn = "Recognized highlight text" }
+        val viewModel = createViewModel(textAnalyzer = fakeTextAnalyzer)
+        var goBackCalled = false
+
+        composeTestRule.setContent {
+            AppTheme {
+                EditAndSaveHighlightScreen(
+                    viewModel = viewModel,
+                    uri = Uri.parse("content://test.jpg"),
+                    bookId = "book-id",
+                    goBack = { goBackCalled = true }
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Recognized highlight text").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithTag("SaveHighlightButton").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) { goBackCalled }
+        assertTrue(goBackCalled)
+    }
+
+    @Test
+    fun whenEditFlowScreenIsDisplayedThenLoadedHighlightTextAndTitleAreShown() {
+        val viewModel = createViewModel()
+
+        composeTestRule.setContent {
+            AppTheme {
+                EditAndSaveHighlightScreen(
+                    viewModel = viewModel,
+                    highlightId = "highlight-id",
+                    bookId = "book-id",
+                    goBack = {}
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Test highlight text").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Edit highlight").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenEditFlowLoadFailsThenErrorSnackbarIsShown() {
+        val fakeHighlightsRepository = FakeHighlightsRepository().apply {
+            shouldLoadHighlightFromDbThrowException = true
+        }
+        val viewModel = createViewModel(highlightsRepository = fakeHighlightsRepository)
+
+        composeTestRule.setContent {
+            AppTheme {
+                EditAndSaveHighlightScreen(
+                    viewModel = viewModel,
+                    highlightId = "highlight-id",
+                    bookId = "book-id",
+                    goBack = {}
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Error processing image for highlight text.")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun whenEditFlowUpdateFailsThenErrorSnackbarIsShown() {
+        val fakeHighlightsRepository = FakeHighlightsRepository().apply {
+            shouldInsertHighlightIntoDbThrowException = true
+        }
+        val viewModel = createViewModel(highlightsRepository = fakeHighlightsRepository)
+
+        composeTestRule.setContent {
+            AppTheme {
+                EditAndSaveHighlightScreen(
+                    viewModel = viewModel,
+                    highlightId = "highlight-id",
+                    bookId = "book-id",
+                    goBack = {}
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Test highlight text").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithTag("SaveHighlightButton").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Error saving highlight.").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun whenEditFlowUpdateSucceedsThenGoBackIsInvoked() {
+        val viewModel = createViewModel()
+        var goBackCalled = false
+
+        composeTestRule.setContent {
+            AppTheme {
+                EditAndSaveHighlightScreen(
+                    viewModel = viewModel,
+                    highlightId = "highlight-id",
+                    bookId = "book-id",
+                    goBack = { goBackCalled = true }
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Test highlight text").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithTag("SaveHighlightButton").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) { goBackCalled }
+        assertTrue(goBackCalled)
     }
 }

--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/ImageRotaterTest.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/ImageRotaterTest.kt
@@ -1,0 +1,140 @@
+package com.sriniketh.feature_addhighlight
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.net.Uri
+import androidx.exifinterface.media.ExifInterface
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+@RunWith(AndroidJUnit4::class)
+class ImageRotaterTest {
+
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val sourceWidth = 4
+    private val sourceHeight = 2
+
+    private fun writeTestImage(fileName: String, orientation: Int?): Uri {
+        val bitmap = Bitmap.createBitmap(sourceWidth, sourceHeight, Bitmap.Config.ARGB_8888)
+        bitmap.eraseColor(Color.BLACK)
+        bitmap.setPixel(0, 0, Color.RED)
+
+        val file = File(context.cacheDir, fileName)
+        FileOutputStream(file).use { outputStream ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+        }
+
+        if (orientation != null) {
+            val exifInterface = ExifInterface(file.absolutePath)
+            exifInterface.setAttribute(ExifInterface.TAG_ORIENTATION, orientation.toString())
+            exifInterface.saveAttributes()
+        }
+
+        return Uri.fromFile(file)
+    }
+
+    @Test
+    fun whenExifOrientationIsNormalThenBitmapIsUnrotated() {
+        val uri = writeTestImage("normal.png", ExifInterface.ORIENTATION_NORMAL)
+
+        val rotated = ImageRotater.getRotatedBitmap(context, uri)
+
+        assertNotNull(rotated)
+        assertEquals(sourceWidth, rotated!!.width)
+        assertEquals(sourceHeight, rotated.height)
+        assertEquals(Color.RED, rotated.getPixel(0, 0))
+    }
+
+    @Test
+    fun whenExifOrientationIsMissingThenBitmapIsUnrotated() {
+        val uri = writeTestImage("missing_orientation.png", orientation = null)
+
+        val rotated = ImageRotater.getRotatedBitmap(context, uri)
+
+        assertNotNull(rotated)
+        assertEquals(sourceWidth, rotated!!.width)
+        assertEquals(sourceHeight, rotated.height)
+        assertEquals(Color.RED, rotated.getPixel(0, 0))
+    }
+
+    @Test
+    fun whenExifOrientationIsRotate90ThenBitmapDimensionsAreSwappedAndContentRotatedClockwise() {
+        val uri = writeTestImage("rotate90.png", ExifInterface.ORIENTATION_ROTATE_90)
+
+        val rotated = ImageRotater.getRotatedBitmap(context, uri)
+
+        assertNotNull(rotated)
+        assertEquals(sourceHeight, rotated!!.width)
+        assertEquals(sourceWidth, rotated.height)
+        assertEquals(Color.RED, rotated.getPixel(rotated.width - 1, 0))
+    }
+
+    @Test
+    fun whenExifOrientationIsRotate180ThenBitmapDimensionsAreUnchangedAndContentRotatedHalfway() {
+        val uri = writeTestImage("rotate180.png", ExifInterface.ORIENTATION_ROTATE_180)
+
+        val rotated = ImageRotater.getRotatedBitmap(context, uri)
+
+        assertNotNull(rotated)
+        assertEquals(sourceWidth, rotated!!.width)
+        assertEquals(sourceHeight, rotated.height)
+        assertEquals(Color.RED, rotated.getPixel(rotated.width - 1, rotated.height - 1))
+    }
+
+    @Test
+    fun whenExifOrientationIsRotate270ThenBitmapDimensionsAreSwappedAndContentRotatedCounterClockwise() {
+        val uri = writeTestImage("rotate270.png", ExifInterface.ORIENTATION_ROTATE_270)
+
+        val rotated = ImageRotater.getRotatedBitmap(context, uri)
+
+        assertNotNull(rotated)
+        assertEquals(sourceHeight, rotated!!.width)
+        assertEquals(sourceWidth, rotated.height)
+        assertEquals(Color.RED, rotated.getPixel(0, rotated.height - 1))
+    }
+
+    @Test
+    fun whenRotate90AndRotate270ThenContentEndsUpInDifferentCorners() {
+        val rotated90 = ImageRotater.getRotatedBitmap(
+            context,
+            writeTestImage("rotate90_vs_270_a.png", ExifInterface.ORIENTATION_ROTATE_90)
+        )
+        val rotated270 = ImageRotater.getRotatedBitmap(
+            context,
+            writeTestImage("rotate90_vs_270_b.png", ExifInterface.ORIENTATION_ROTATE_270)
+        )
+
+        assertNotNull(rotated90)
+        assertNotNull(rotated270)
+        assertEquals(Color.RED, rotated90!!.getPixel(rotated90.width - 1, 0))
+        assertEquals(Color.RED, rotated270!!.getPixel(0, rotated270.height - 1))
+        assertEquals(Color.BLACK, rotated90.getPixel(0, rotated90.height - 1))
+        assertEquals(Color.BLACK, rotated270.getPixel(rotated270.width - 1, 0))
+    }
+
+    @Test
+    fun whenImageUriPointsToNonExistentFileThenNullIsReturned() {
+        val missingUri = Uri.fromFile(File(context.cacheDir, "does-not-exist.png"))
+
+        val rotated = ImageRotater.getRotatedBitmap(context, missingUri)
+
+        assertNull(rotated)
+    }
+
+    @Test
+    fun whenImageUriIsMalformedThenNullIsReturned() {
+        val invalidUri = Uri.parse("content://com.sriniketh.feature_addhighlight.unknown.provider/missing")
+
+        val rotated = ImageRotater.getRotatedBitmap(context, invalidUri)
+
+        assertNull(rotated)
+    }
+}

--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/TextAnalyzerImplTest.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/TextAnalyzerImplTest.kt
@@ -1,0 +1,65 @@
+package com.sriniketh.feature_addhighlight
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.mlkit.common.MlKitException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+@RunWith(AndroidJUnit4::class)
+class TextAnalyzerImplTest {
+
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private fun renderTextImageUri(text: String): Uri {
+        val width = 600
+        val height = 200
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(Color.WHITE)
+        val paint = Paint().apply {
+            color = Color.BLACK
+            textSize = 90f
+            isAntiAlias = true
+        }
+        canvas.drawText(text, 30f, height / 2f + 30f, paint)
+
+        val file = File(context.cacheDir, "ocr_test_image.png")
+        FileOutputStream(file).use { outputStream ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+        }
+        return Uri.fromFile(file)
+    }
+
+    @Test
+    fun whenImageContainsRenderedTextThenRecognizedTextContainsIt() = runBlocking {
+        val textAnalyzer = TextAnalyzerImpl(context)
+        val imageUri = renderTextImageUri("PROSE")
+
+        val result = try {
+            withTimeout(90_000) { textAnalyzer.analyzeImage(imageUri) }
+        } catch (mlKitException: MlKitException) {
+            Assume.assumeNoException(
+                "On-device text recognition model is unavailable on this device (no signed-in " +
+                    "Play Store account to download the optional module), so the real recognizer " +
+                    "cannot run here. Skipping rather than faking a recognized result.",
+                mlKitException
+            )
+            return@runBlocking
+        }
+
+        assertTrue(result.text.uppercase().contains("PROSE"))
+    }
+}

--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/fakes/FakeDateTimeSource.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/fakes/FakeDateTimeSource.kt
@@ -1,0 +1,11 @@
+package com.sriniketh.feature_addhighlight.fakes
+
+import com.sriniketh.core_platform.DateTimeSource
+import java.time.LocalDateTime
+
+class FakeDateTimeSource : DateTimeSource {
+
+    var currentTime: LocalDateTime = LocalDateTime.of(2023, 1, 1, 12, 0, 0)
+
+    override fun now(): LocalDateTime = currentTime
+}

--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/fakes/FakeFileSource.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/fakes/FakeFileSource.kt
@@ -1,0 +1,22 @@
+package com.sriniketh.feature_addhighlight.fakes
+
+import android.net.Uri
+import com.sriniketh.core_platform.FileSource
+
+class FakeFileSource(private val uriToReturn: Uri = Uri.parse("content://test.jpg")) : FileSource {
+
+    val deletedUris = mutableListOf<Uri>()
+    val createdFileNames = mutableListOf<String>()
+
+    override fun createNewFile(fileName: String): Uri {
+        createdFileNames.add(fileName)
+        return uriToReturn
+    }
+
+    override fun writeToFile(fileName: String, content: String): Uri = uriToReturn
+
+    override fun deleteFile(uri: Uri): Boolean {
+        deletedUris.add(uri)
+        return true
+    }
+}

--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/fakes/FakeHighlightsRepository.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/fakes/FakeHighlightsRepository.kt
@@ -1,0 +1,43 @@
+package com.sriniketh.feature_addhighlight.fakes
+
+import com.sriniketh.core_data.HighlightsRepository
+import com.sriniketh.core_models.book.Highlight
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class FakeHighlightsRepository : HighlightsRepository {
+
+    var shouldInsertHighlightIntoDbThrowException = false
+    var shouldLoadHighlightFromDbThrowException = false
+    var insertedHighlight: Highlight? = null
+
+    private val fakeHighlight = Highlight(
+        id = "test-highlight-id",
+        bookId = "test-book-id",
+        text = "Test highlight text",
+        savedOnTimestamp = "2023-01-01"
+    )
+
+    override fun getAllHighlightsForBookFromDb(bookId: String): Flow<Result<List<Highlight>>> = flow {
+        emit(Result.success(listOf(fakeHighlight)))
+    }
+
+    override suspend fun deleteHighlightFromDb(highlightId: String): Result<Unit> = Result.success(Unit)
+
+    override suspend fun insertHighlightIntoDb(highlight: Highlight): Result<Unit> {
+        insertedHighlight = highlight
+        return if (shouldInsertHighlightIntoDbThrowException) {
+            Result.failure(RuntimeException("Insert highlight failed"))
+        } else {
+            Result.success(Unit)
+        }
+    }
+
+    override suspend fun loadHighlightFromDb(highlightId: String): Result<Highlight> {
+        return if (shouldLoadHighlightFromDbThrowException) {
+            Result.failure(RuntimeException("Load highlight failed"))
+        } else {
+            Result.success(fakeHighlight)
+        }
+    }
+}

--- a/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/fakes/FakeTextAnalyzer.kt
+++ b/feature-addhighlight/src/androidTest/java/com/sriniketh/feature_addhighlight/fakes/FakeTextAnalyzer.kt
@@ -1,0 +1,20 @@
+package com.sriniketh.feature_addhighlight.fakes
+
+import android.net.Uri
+import com.google.mlkit.vision.text.Text
+import com.sriniketh.feature_addhighlight.TextAnalyzer
+
+class FakeTextAnalyzer : TextAnalyzer {
+
+    var shouldThrowException = false
+    var analyzedUri: Uri? = null
+    var textToReturn = "Fake analyzed text from image"
+
+    override suspend fun analyzeImage(uri: Uri): Text {
+        analyzedUri = uri
+        if (shouldThrowException) {
+            throw RuntimeException("Text analysis failed")
+        }
+        return Text(textToReturn, emptyList<Text.TextBlock>())
+    }
+}


### PR DESCRIPTION
Adds instrumented (androidTest) coverage for the five weakest-covered files in `feature-addhighlight`, per the latest Codecov report on `main`. No production code changed — all gaps are closed with tests.

## TextAnalyzer.kt (0% -> real recognizer exercised)
New `TextAnalyzerImplTest` renders a bitmap containing the word "PROSE" and runs it through the real on-device `TextRecognizer` via `TextAnalyzerImpl`. This emulator has no signed-in Play Store account, so the optional OCR model can't download and `MlKitException("Waiting for the text optional module to be downloaded")` is thrown immediately and consistently (verified twice). The test still attempts the real call and only falls back to `Assume.assumeNoException(...)` (skip, not a fake pass) on that specific exception, so it validates real OCR end-to-end wherever the model is available, and never fakes a recognized result. Locally the attempt itself already exercises the failure-listener path for real: `TextAnalyzerImpl` goes from 0/9 to 9/9 lines covered in the local instrumented report (the one still-uncovered branch is the success-listener lambda, which needs the model to actually be present).

## ImageRotater.kt (13.8%, 4/29 lines -> ~86%, 25/29 lines locally)
New `ImageRotaterTest` writes real PNGs to disk with `ExifInterface` orientation tags (NORMAL, ROTATE_90/180/270, and no tag) and asserts both dimension swaps and the actual destination pixel a marker color ends up at, for each rotation. Expected positions were derived from the rotation-matrix math first, then confirmed by the real pixel positions on-device (all assertions passed as derived, no post-hoc adjustment). Also covers the two failure paths: a URI pointing at a non-existent file, and a URI with an unrecognized content authority — both return `null` via the existing outer try/catch. One narrow branch is left uncovered: `openInputStream` returning `null` without throwing (lines 17-20) — Android's real `ContentResolver` throws rather than returning null for missing/unknown providers, so this defensive branch isn't practically reachable without a custom fake `ContentProvider`; not worth the complexity for a few defensive lines that never fire in practice.

## CaptureAndCropImageScreen.kt (0/22 lines -> real composable now exercised)
The existing test file only exercised a hand-duplicated copy of the screen's `when` block, so the real file stayed at 0% despite tests existing. Added cases that drive a real `CaptureAndCropImageViewModel` into `CropImage` and `ImageCapturedAndCropped` state *before* composing the real `CaptureAndCropImageScreen`, so the real production composable (not a copy) renders `CropImageScreen` / invokes `onImageCaptured`. Left deliberately untested: the `CaptureImage` branch's `cameraLauncher.launch(...)` line — there's no camera app on this emulator, and even where one exists, launching it would be nondeterministic and out of process. Kept the original duplicated-composable tests as-is (they still pass) rather than deleting working tests.

## CropImageScreen.kt (63.6%, 35/55 -> ~89%, 42/47 lines locally)
Added a real-image success path: a valid PNG is loaded, the crop FAB is clicked, and the test waits for `onImageCropped` to fire, then verifies a valid bitmap was written back through the URI's `ContentResolver` — this exercises the `Cropify(bitmap = ...)` / crop-and-write branch the old mock-URI-only tests never reached. Also added an explicit "image fails to load" case asserting `onFailedToLoadImage` correctly still calls back into `onImageCropped`.

## EditAndSaveHighlightScreen.kt (47.5%, 66/139 -> ~89%, 103/116 lines locally)
The existing tests only ever called the stateless inner `EditAndSaveHighlight` composable directly, so the two public `EditAndSaveHighlightScreen` overloads (capture flow and edit flow) — LaunchedEffect-driven image processing / highlight loading, and the effects collector wiring snackbars and navigation — were never invoked. Added cases with a real `EditAndSaveHighlightViewModel` covering: recognized text appearing in the field after capture-flow processing, error snackbar on OCR failure, save-success navigating back, loaded text + title on edit-flow, error snackbar on load failure, error snackbar on update failure, and update-success navigating back.

## Fakes
Added androidTest-local `FakeTextAnalyzer`, `FakeHighlightsRepository`, `FakeDateTimeSource`, `FakeFileSource` mirroring the existing `src/test` fakes (androidTest is a separate source set and can't see them). `FakeTextAnalyzer` builds a real ML Kit `Text` via its public `(String, List<TextBlock>)` constructor instead of mocking it, consistent with this codebase's convention of no MockK in androidTest.

## Verification
All 34 instrumented tests pass locally on Pixel_8 API 34 (33 pass, 1 environment-gated skip as described above), and the existing unit test suite (`testDebugUnitTest`) still passes unchanged.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
