### PR TITLE
Add instrumented tests for MainActivity and app navigation graph

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,4 +26,7 @@ dependencies {
     implementation(libs.coroutines.android)
     implementation(libs.timber)
     implementation(libs.navigation.compose)
+
+    androidTestImplementation(project(":core-db"))
+    androidTestImplementation(libs.room.runtime)
 }

--- a/app/src/androidTest/java/com/sriniketh/prose/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/sriniketh/prose/MainActivityTest.kt
@@ -1,0 +1,33 @@
+package com.sriniketh.prose
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun whenMainActivityLaunchesThenBookshelfPageTitleIsDisplayed() {
+        composeTestRule.onNodeWithText("Bookshelf").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenMainActivityLaunchesThenSearchForABookButtonIsDisplayed() {
+        composeTestRule.onNodeWithContentDescription("search for a book button").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenMainActivityLaunchesThenNoOtherScreenContentIsDisplayed() {
+        composeTestRule.onNodeWithTag("SearchBookTextField").assertDoesNotExist()
+    }
+}

--- a/app/src/androidTest/java/com/sriniketh/prose/ProseAppScreenNavigationTest.kt
+++ b/app/src/androidTest/java/com/sriniketh/prose/ProseAppScreenNavigationTest.kt
@@ -1,0 +1,127 @@
+package com.sriniketh.prose
+
+import android.content.Context
+import android.view.KeyEvent
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.sriniketh.core_db.BookDatabase
+import com.sriniketh.core_db.entity.BookEntity
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+
+private const val BOOK_DATABASE_NAME = "book-db"
+
+private class SeededBookRule : ExternalResource() {
+
+    val book = BookEntity(
+        id = "prose-app-screen-navigation-test-book-${System.nanoTime()}",
+        title = "Navigation Test Book",
+        subtitle = null,
+        authors = listOf("Navigation Test Author"),
+        thumbnailLink = null,
+        publisher = null,
+        publishedDate = null,
+        description = null,
+        pageCount = null,
+        averageRating = null,
+        ratingsCount = null
+    )
+
+    override fun before() {
+        withDatabase { it.bookDao().insertBook(book) }
+    }
+
+    override fun after() {
+        withDatabase { it.bookDao().deleteBook(book) }
+    }
+
+    private fun withDatabase(action: suspend (BookDatabase) -> Unit) {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.databaseBuilder(context, BookDatabase::class.java, BOOK_DATABASE_NAME).build()
+        try {
+            runBlocking { action(database) }
+        } finally {
+            database.close()
+        }
+    }
+}
+
+@RunWith(AndroidJUnit4::class)
+class ProseAppScreenNavigationTest {
+
+    private val seededBookRule = SeededBookRule()
+    private val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(seededBookRule).around(composeTestRule)
+
+    private val seededBookId get() = seededBookRule.book.id
+
+    @Test
+    fun whenSearchButtonIsClickedThenSearchScreenIsDisplayed() {
+        composeTestRule.onNodeWithContentDescription("search for a book button").performClick()
+
+        composeTestRule.onNodeWithTag("SearchBookTextField").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Bookshelf").assertDoesNotExist()
+    }
+
+    @Test
+    fun whenBackIsPressedFromSearchScreenThenBookshelfScreenIsDisplayedAgain() {
+        composeTestRule.onNodeWithContentDescription("search for a book button").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").assertIsDisplayed()
+
+        pressSystemBackUntilBookshelfIsDisplayed()
+
+        composeTestRule.onNodeWithContentDescription("search for a book button").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenASeededBookItemIsClickedThenViewHighlightsScreenIsDisplayedForThatBook() {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            runCatching { composeTestRule.onNodeWithTag("BookItem_$seededBookId").assertIsDisplayed() }.isSuccess
+        }
+
+        composeTestRule.onNodeWithTag("BookItem_$seededBookId").performClick()
+
+        composeTestRule.onNodeWithText("Saved highlights").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No saved highlights").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenBackIsPressedFromViewHighlightsScreenThenBookshelfScreenIsDisplayedAgain() {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            runCatching { composeTestRule.onNodeWithTag("BookItem_$seededBookId").assertIsDisplayed() }.isSuccess
+        }
+        composeTestRule.onNodeWithTag("BookItem_$seededBookId").performClick()
+        composeTestRule.onNodeWithText("Saved highlights").assertIsDisplayed()
+
+        composeTestRule.onNodeWithContentDescription("Go back").performClick()
+
+        composeTestRule.onNodeWithText("Bookshelf").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("BookItem_$seededBookId").assertIsDisplayed()
+    }
+
+    private fun pressSystemBackUntilBookshelfIsDisplayed(maxPresses: Int = 5) {
+        var presses = 0
+        while (presses < maxPresses &&
+            runCatching { composeTestRule.onNodeWithText("Bookshelf").assertIsDisplayed() }.isFailure
+        ) {
+            InstrumentationRegistry.getInstrumentation().sendKeyDownUpSync(KeyEvent.KEYCODE_BACK)
+            composeTestRule.waitForIdle()
+            presses++
+        }
+        composeTestRule.onNodeWithText("Bookshelf").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## Summary

`MainActivity.kt` and `ProseAppScreen.kt` (the app's NavHost wiring) had 0% test coverage per Codecov on `main`. Both are thin, Hilt-wired real UI/navigation glue, so unit tests can't meaningfully exercise them — this adds instrumented tests instead.

## What's added

- `app/src/androidTest/java/com/sriniketh/prose/MainActivityTest.kt` — launches the real `MainActivity` and asserts the Bookshelf start destination renders (page title, search FAB, no other screen's content present).
- `app/src/androidTest/java/com/sriniketh/prose/ProseAppScreenNavigationTest.kt` — drives real navigation through the `NavHost` hosted by `MainActivity`:
  - bookshelf → search (FAB click) → back (system back key)
  - bookshelf → view highlights (book item click) → back (in-screen back button)

Each assertion checks the destination screen's distinctive content (page title, test tags, empty-state text), not just that navigation happened.

## Why real navigation instead of test doubles

The task called for testing real end-to-end navigation if Hilt test-double infrastructure already existed at the app level. It doesn't: there's no `@HiltAndroidTest`/`@UninstallModules`/`@TestInstallIn`/`@BindValue` anywhere in this codebase, no `hilt-android-testing` dependency, and no `kspAndroidTest` wiring for the Hilt compiler — existing feature-level instrumented tests (`BookshelfScreenTest`, `ViewHighlightsScreenTest`, etc.) avoid this entirely by testing the stateless composable directly with fake UI state, never composing the real `hiltViewModel()`-backed screen. Building that infrastructure just for this coverage task would be disproportionate.

Instead, the view-highlights test seeds one real `BookEntity` row directly through a second `Room` instance pointed at the same `"book-db"` file the app's Hilt-provided database uses, via a `RuleChain` that runs the seed *before* `MainActivity` launches (so it's present for the very first query — no cross-instance invalidation timing to worry about), and removes it in `after()`. This gets a real book on the shelf to click through to a real `ViewHighlightsScreen`, without touching Hilt wiring at all. Cost: a new `androidTestImplementation(project(":core-db"))` + `androidTestImplementation(libs.room.runtime)` test-only dependency in `app/build.gradle.kts`.

## A note on the search screen back-press test

The search screen's `SearchBar` auto-focuses and opens its IME/expanded state on entry, so a single system back press only dismisses the keyboard/collapses focus — it takes a couple of back presses before the event reaches the `NavController`. `pressSystemBackUntilBookshelfIsDisplayed()` retries up to 5 times instead of hardcoding a magic press count, since the exact number is an SDK/keyboard-state implementation detail that could shift across environments.

## What's still not covered

- **Search → Book Info**: `BookInfoScreen` fetches over the network on entry (`getBookDetail` in a `LaunchedEffect`), and getting there from Search requires an actual search result. Exercising this needs either a live network call to the Google Books API (non-hermetic, no existing instrumented test in the repo does this) or Hilt test doubles for the network layer, which don't exist.
- **Capture/crop/OCR and the two `EditAndSaveHighlight` routes**: require camera capture, ML Kit OCR, or an existing highlight id, none of which are reasonably seedable without either real camera hardware or, again, Hilt test doubles.

Both gaps stem from the same root cause — no DI test-double infrastructure at the app level — and are out of scope for a coverage-only change. Building that infrastructure (a `HiltTestApplication` + custom test runner, `hilt-android-testing`, `@TestInstallIn` fakes for network/DB) would be a reasonable follow-up if this app-level layer needs deeper instrumented coverage.

## Testing

`./gradlew :app:connectedDebugAndroidTest` — 12/12 tests pass (7 new + 5 pre-existing `FileSourceImplTest`), run on the shared `Pixel_8` API 34 emulator per the project's testing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)