### PR TITLE
Close feature-searchbooks Screen coverage gaps at the UI-test level

### DIFF
--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/BookInfoScreenTest.kt
@@ -1,21 +1,27 @@
 package com.sriniketh.feature_searchbooks
 
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme
+import com.sriniketh.feature_searchbooks.fakes.FakeBooksRepository
 import kotlinx.collections.immutable.toImmutableList
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(ExperimentalTestApi::class)
 @RunWith(AndroidJUnit4::class)
 class BookInfoScreenTest {
 
@@ -353,6 +359,98 @@ class BookInfoScreenTest {
         }
 
         composeTestRule.onNodeWithText("Test Description").assertDoesNotExist()
+    }
+
+    @Test
+    fun whenBookIdIsProvidedThenBookDetailIsLoadedFromScreen() {
+        val fakeBooksRepository = FakeBooksRepository()
+        val viewModel = BookInfoViewModel(fakeBooksRepository)
+
+        composeTestRule.setContent {
+            AppTheme {
+                BookInfoScreen(
+                    viewModel = viewModel,
+                    bookId = "test-volume-id",
+                    goBack = {}
+                )
+            }
+        }
+
+        composeTestRule.waitUntilAtLeastOneExists(hasText("Test Title"), timeoutMillis = 5_000)
+        composeTestRule.onNodeWithText("Test Title").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenLoadFailsThenErrorSnackbarIsShownFromScreen() {
+        val fakeBooksRepository = FakeBooksRepository().apply {
+            shouldFetchBookInfoThrowException = true
+        }
+        val viewModel = BookInfoViewModel(fakeBooksRepository)
+
+        composeTestRule.setContent {
+            AppTheme {
+                BookInfoScreen(
+                    viewModel = viewModel,
+                    bookId = "test-volume-id",
+                    goBack = {}
+                )
+            }
+        }
+
+        composeTestRule.waitUntilAtLeastOneExists(
+            hasText("Error loading book details."),
+            timeoutMillis = 5_000
+        )
+        composeTestRule.onNodeWithText("Error loading book details.").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenAddingToShelfSucceedsFromScreenThenOnBookAddedToShelfIsCalled() {
+        val fakeBooksRepository = FakeBooksRepository().apply {
+            doesBookExistResult = false
+        }
+        val viewModel = BookInfoViewModel(fakeBooksRepository)
+        var onBookAddedToShelfCalled = false
+
+        composeTestRule.setContent {
+            AppTheme {
+                BookInfoScreen(
+                    viewModel = viewModel,
+                    bookId = "test-volume-id",
+                    goBack = {},
+                    onBookAddedToShelf = { onBookAddedToShelfCalled = true }
+                )
+            }
+        }
+
+        composeTestRule.waitUntilAtLeastOneExists(
+            hasContentDescription("Add to shelf"),
+            timeoutMillis = 5_000
+        )
+        composeTestRule.onNodeWithContentDescription("Add to shelf").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) { onBookAddedToShelfCalled }
+        assertTrue(onBookAddedToShelfCalled)
+    }
+
+    @Test
+    fun whenBackButtonIsClickedFromScreenThenGoBackIsCalled() {
+        val fakeBooksRepository = FakeBooksRepository()
+        val viewModel = BookInfoViewModel(fakeBooksRepository)
+        var goBackCalled = false
+
+        composeTestRule.setContent {
+            AppTheme {
+                BookInfoScreen(
+                    viewModel = viewModel,
+                    bookId = "test-volume-id",
+                    goBack = { goBackCalled = true }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Go back").performClick()
+        assertTrue(goBackCalled)
     }
 
     private fun createTestBook(

--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/SearchBookScreenTest.kt
@@ -1,9 +1,12 @@
 package com.sriniketh.feature_searchbooks
 
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTouchHeightIsEqualTo
 import androidx.compose.ui.test.assertTouchWidthIsEqualTo
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -12,19 +15,23 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.sriniketh.core_design.ui.theme.AppTheme
+import com.sriniketh.feature_searchbooks.fakes.FakeBooksRepository
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(ExperimentalTestApi::class)
 @RunWith(AndroidJUnit4::class)
 class SearchBookScreenTest {
 
@@ -373,6 +380,103 @@ class SearchBookScreenTest {
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("New Top Book 0").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenSearchActionIsTriggeredWithShortQueryThenSearchForBooksIsNotCalled() {
+        val uiState = BookSearchUiState()
+        var searchQuery: String? = null
+
+        composeTestRule.setContent {
+            AppTheme {
+                SearchBook(
+                    uiState = uiState,
+                    searchForBooks = { searchQuery = it },
+                    navigateToBookInfo = {},
+                    resetSearch = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performTextInput("abc")
+        composeTestRule.onNodeWithTag("SearchBookTextField").performImeAction()
+
+        assertNull(searchQuery)
+    }
+
+    @Test
+    fun whenSearchFailsThenErrorSnackbarIsShownFromScreen() {
+        val fakeBooksRepository = FakeBooksRepository().apply {
+            shouldSearchForBooksThrowException = true
+        }
+        val viewModel = SearchBookViewModel(fakeBooksRepository)
+
+        composeTestRule.setContent {
+            AppTheme {
+                SearchBookScreen(
+                    viewModel = viewModel,
+                    goToBookInfo = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performTextInput("test query")
+
+        composeTestRule.waitUntilAtLeastOneExists(
+            hasText("Error searching for book. Please try again."),
+            timeoutMillis = 5_000
+        )
+        composeTestRule.onNodeWithText("Error searching for book. Please try again.")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun whenBookItemIsClickedFromScreenThenGoToBookInfoIsCalledWithVolumeId() {
+        val fakeBooksRepository = FakeBooksRepository()
+        val viewModel = SearchBookViewModel(fakeBooksRepository)
+        var navigatedBookId: String? = null
+
+        composeTestRule.setContent {
+            AppTheme {
+                SearchBookScreen(
+                    viewModel = viewModel,
+                    goToBookInfo = { navigatedBookId = it }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performTextInput("test query")
+
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SearchResultItem_test-id"), timeoutMillis = 5_000)
+        composeTestRule.onNodeWithTag("SearchResultItem_test-id").performClick()
+
+        assertEquals("test-id", navigatedBookId)
+    }
+
+    @Test
+    fun whenCloseIconIsClickedFromScreenThenResultsAreClearedThroughViewModel() {
+        val fakeBooksRepository = FakeBooksRepository()
+        val viewModel = SearchBookViewModel(fakeBooksRepository)
+
+        composeTestRule.setContent {
+            AppTheme {
+                SearchBookScreen(
+                    viewModel = viewModel,
+                    goToBookInfo = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("SearchBookTextField").performClick()
+        composeTestRule.onNodeWithTag("SearchBookTextField").performTextInput("test query")
+
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("SearchResultItem_test-id"), timeoutMillis = 5_000)
+        composeTestRule.onNodeWithContentDescription("Close icon").performClick()
+
+        composeTestRule.onNodeWithTag("SearchResultItem_test-id").assertDoesNotExist()
     }
 
     @Test

--- a/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/fakes/FakeBooksRepository.kt
+++ b/feature-searchbooks/src/androidTest/java/com/sriniketh/feature_searchbooks/fakes/FakeBooksRepository.kt
@@ -1,0 +1,71 @@
+package com.sriniketh.feature_searchbooks.fakes
+
+import com.sriniketh.core_data.BooksRepository
+import com.sriniketh.core_models.book.Book
+import com.sriniketh.core_models.book.BookInfo
+import com.sriniketh.core_models.search.BookSearch
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class FakeBooksRepository : BooksRepository {
+
+    var shouldSearchForBooksThrowException = false
+    var shouldFetchBookInfoThrowException = false
+    var shouldInsertBookIntoDboThrowException = false
+
+    var doesBookExistResult = false
+    var insertedBook: Book? = null
+
+    var searchResultBuilder: (String) -> BookSearch = { BookSearch(items = listOf(fakeBook)) }
+
+    val fakeBook = Book(
+        id = "test-id",
+        info = BookInfo(
+            title = "Test Title",
+            subtitle = "Test Subtitle",
+            authors = listOf("Test Author"),
+            thumbnailLink = null,
+            publisher = "Test Publisher",
+            publishedDate = "2023",
+            description = "Test Description",
+            pageCount = 200,
+            averageRating = 4.5,
+            ratingsCount = 100
+        )
+    )
+
+    override suspend fun searchForBooks(searchQuery: String): Result<BookSearch> {
+        return if (shouldSearchForBooksThrowException) {
+            Result.failure(RuntimeException("Search failed"))
+        } else {
+            Result.success(searchResultBuilder(searchQuery))
+        }
+    }
+
+    override suspend fun fetchBookInfo(volumeId: String): Result<Book> {
+        return if (shouldFetchBookInfoThrowException) {
+            Result.failure(RuntimeException("Fetch book info failed"))
+        } else {
+            Result.success(fakeBook)
+        }
+    }
+
+    override suspend fun insertBookIntoDb(book: Book): Result<Unit> {
+        insertedBook = book
+        return if (shouldInsertBookIntoDboThrowException) {
+            Result.failure(RuntimeException("Insert book failed"))
+        } else {
+            Result.success(Unit)
+        }
+    }
+
+    override suspend fun doesBookExistInDb(bookId: String): Boolean = doesBookExistResult
+
+    override fun getAllSavedBooksFromDb(): Flow<Result<List<Book>>> = flow {
+        emit(Result.success(listOf(fakeBook)))
+    }
+
+    override suspend fun getBookByIdFromDb(bookId: String): Result<Book> = Result.success(fakeBook)
+
+    override suspend fun deleteBookFromDb(book: Book): Result<Unit> = Result.success(Unit)
+}


### PR DESCRIPTION
## What

Codecov flagged two `feature-searchbooks` files with meaningful gaps: `SearchBookScreen.kt` (72.5%, 116/160) and `BookInfoScreen.kt` (73.6%, 142/193). Read both production files against `SearchBookScreenTest.kt`/`BookInfoScreenTest.kt` and the ViewModel unit tests, then closed the gaps at the UI-test level.

## Gaps found

Both files had the same shape of gap: the internal `SearchBook`/`BookInfo` composables (the ones taking `uiState` directly) were already thoroughly covered by the existing test suites. The uncovered lines were almost entirely the outer `SearchBookScreen`/`BookInfoScreen` wrapper composables — `LaunchedEffect` blocks wiring a real `hiltViewModel()`-backed ViewModel to the internal composable, plus effect collection for snackbars/navigation — which no test in the module (or any sibling feature module) exercised. `SearchBookScreen.kt` also had one missed branch: `onSearch`'s short-query check (`if (text.length > 3)`) was only tested for the true case via IME action.

`SearchBookViewModel` (84.6%) and `BookInfoViewModel` (92.2%) were already fully exercised by their existing Turbine-based unit tests for every branch — no gap traced back to the ViewModels themselves, so no unit tests were added there.

## What was added

The wrapper composables' only dependency beyond `Modifier`/callbacks is a plain `BooksRepository`-backed ViewModel — not Hilt itself — so they can be driven directly: construct `SearchBookViewModel`/`BookInfoViewModel` with a fake repository and pass it in place of the `hiltViewModel()` default, no Hilt test infra required. Added `feature-searchbooks/src/androidTest/.../fakes/FakeBooksRepository.kt` (mirrors the existing unit-test fake in `src/test`, since androidTest and test are separate source sets) and new tests in the existing `SearchBookScreenTest`/`BookInfoScreenTest` files driving the wrapper end to end:

- `SearchBookScreenTest`: short-query IME action doesn't search, search failure shows a snackbar, tapping a result invokes `goToBookInfo` with the volume id, clearing search invokes `resetSearch`.
- `BookInfoScreenTest`: book detail loads via `LaunchedEffect(bookId)`, load failure shows a snackbar, add-to-shelf triggers `onBookAddedToShelf`, back button invokes `goBack`.

Since these run with real (non-test) coroutine dispatchers, async assertions use `waitUntilAtLeastOneExists`/`waitUntil` with wall-clock timeouts rather than assuming synchronous state.

## Deliberately left uncovered

- The `hiltViewModel()` default expression itself — only reachable through real DI, not worth standing up Hilt android-test infra for one line.
- The closing braces of the `repeatOnLifecycle(STARTED) { effects.collect { ... } } }` block in both wrappers — the collector never completes within a test's lifetime, so its exit path is structurally unreachable in a UI test.
- One branch of the outer `SearchBar`'s `onExpandedChange` in `SearchBookScreen` — fires on system-driven collapse (e.g. back press while the bar is expanded), which would need Espresso interop not otherwise used in this module.
- The `@Preview`/`@PreviewLightDark` functions in both files, per the task's stated scope (being excluded from coverage separately).

## Coverage (measured locally via `createDebugAndroidTestCoverageReport`, excluding `@Preview` functions)

| File | Before | After |
|---|---|---|
| `SearchBookScreen.kt` | 83.3% | 96.7% |
| `BookInfoScreen.kt` | ~85% | 97.2% |

All 44 instrumented tests (36 existing + 8 new) and the full unit test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
